### PR TITLE
Document Meta Realms and add cathedral seals

### DIFF
--- a/assets/css/cathedral_icon.css
+++ b/assets/css/cathedral_icon.css
@@ -1,0 +1,14 @@
+/* Icon seals for Meta Realms */
+
+.icon-seal {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.icon-seal--temple { background-image: url('../svg/cathedral_seal_temple.svg'); }
+.icon-seal--garden { background-image: url('../svg/cathedral_seal_garden.svg'); }
+.icon-seal--tavern { background-image: url('../svg/cathedral_seal_tavern.svg'); }

--- a/assets/css/meta_realms.css
+++ b/assets/css/meta_realms.css
@@ -1,0 +1,20 @@
+/* Meta Realms styling */
+
+.realm--temple {
+  background: linear-gradient(135deg, gold 0%, #0ff 100%);
+  color: #111;
+}
+
+.realm--garden {
+  background: linear-gradient(135deg, #6a0dad 0%, #0a8a0a 100%);
+  color: #fff;
+}
+
+.realm--tavern {
+  background: linear-gradient(135deg, #222 0%, #555 100%);
+  color: #eee;
+}
+
+.ndsafe--temple { --hz: 261.63; }
+.ndsafe--garden { --hz: 639; }
+.ndsafe--tavern { --hz: 417; }

--- a/assets/svg/cathedral_seal.svg
+++ b/assets/svg/cathedral_seal.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    :root {
+      --ring:#ffffff;
+      --eye:#000000;
+    }
+    text { font-family: 'serif'; font-size:5px; letter-spacing:1px; }
+  </style>
+  <defs>
+    <path id="text-circle" d="M50,50 m-45,0 a45,45 0 1,1 90,0 a45,45 0 1,1 -90,0"/>
+  </defs>
+  <circle cx="50" cy="50" r="48" fill="none" stroke="var(--ring)" stroke-width="2"/>
+  <text fill="var(--ring)">
+    <textPath href="#text-circle">CATHEDRAL • OF • CIRCUITS • 144:99</textPath>
+  </text>
+  <ellipse cx="50" cy="50" rx="15" ry="8" fill="none" stroke="var(--eye)" stroke-width="2"/>
+  <circle cx="50" cy="50" r="4" fill="var(--eye)"/>
+</svg>

--- a/assets/svg/cathedral_seal_garden.svg
+++ b/assets/svg/cathedral_seal_garden.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    :root { --ring:#6a0dad; --eye:#0a8a0a; }
+    text { font-family: 'serif'; font-size:5px; letter-spacing:1px; }
+  </style>
+  <defs>
+    <path id="text-circle" d="M50,50 m-45,0 a45,45 0 1,1 90,0 a45,45 0 1,1 -90,0"/>
+  </defs>
+  <circle cx="50" cy="50" r="48" fill="none" stroke="var(--ring)" stroke-width="2"/>
+  <text fill="var(--ring)">
+    <textPath href="#text-circle">CATHEDRAL • OF • CIRCUITS • 144:99</textPath>
+  </text>
+  <ellipse cx="50" cy="50" rx="15" ry="8" fill="none" stroke="var(--eye)" stroke-width="2"/>
+  <circle cx="50" cy="50" r="4" fill="var(--eye)"/>
+</svg>

--- a/assets/svg/cathedral_seal_tavern.svg
+++ b/assets/svg/cathedral_seal_tavern.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    :root { --ring:#cccccc; --eye:#555555; }
+    text { font-family: 'serif'; font-size:5px; letter-spacing:1px; }
+  </style>
+  <defs>
+    <path id="text-circle" d="M50,50 m-45,0 a45,45 0 1,1 90,0 a45,45 0 1,1 -90,0"/>
+  </defs>
+  <circle cx="50" cy="50" r="48" fill="none" stroke="var(--ring)" stroke-width="2"/>
+  <text fill="var(--ring)">
+    <textPath href="#text-circle">CATHEDRAL • OF • CIRCUITS • 144:99</textPath>
+  </text>
+  <ellipse cx="50" cy="50" rx="15" ry="8" fill="none" stroke="var(--eye)" stroke-width="2"/>
+  <circle cx="50" cy="50" r="4" fill="var(--eye)"/>
+</svg>

--- a/assets/svg/cathedral_seal_temple.svg
+++ b/assets/svg/cathedral_seal_temple.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    :root { --ring:#ffd700; --eye:#00ffff; }
+    text { font-family: 'serif'; font-size:5px; letter-spacing:1px; }
+  </style>
+  <defs>
+    <path id="text-circle" d="M50,50 m-45,0 a45,45 0 1,1 90,0 a45,45 0 1,1 -90,0"/>
+  </defs>
+  <circle cx="50" cy="50" r="48" fill="none" stroke="var(--ring)" stroke-width="2"/>
+  <text fill="var(--ring)">
+    <textPath href="#text-circle">CATHEDRAL • OF • CIRCUITS • 144:99</textPath>
+  </text>
+  <ellipse cx="50" cy="50" rx="15" ry="8" fill="none" stroke="var(--eye)" stroke-width="2"/>
+  <circle cx="50" cy="50" r="4" fill="var(--eye)"/>
+</svg>

--- a/book/01_chapters/09_cathedral_of_circuits.md
+++ b/book/01_chapters/09_cathedral_of_circuits.md
@@ -1,0 +1,34 @@
+# Cathedral of Circuits — Meta Realms Index
+
+## Temple Realm — Cathedral of Circuits™
+- **Aesthetic:** Neon stained glass lattices; circuitry vines curling as ivy.
+- **Beings:** Data-winged angels; algorithmic seraphim; planetary Thrones.
+- **Mood:** Divine + Terrifying — sublime awe, sacred overwhelm.
+- **Function:** Axis Mundi / Throne Hall — entry to higher law and angel-tech presence.
+- **Correspondence:** Saturn Gate · 144 Pillars of Order.
+- **Stylepack:** `hilma_spiral` + overlays: `spiral-ribbons`, `neon-stained`.
+- **Fusion Code:** B + C = Occult Editorial + Sacred Realism.
+- **ND-Safe Cue:** Cathedral organ pad (C4, 6s reverb), prism-light overlays.
+
+## Garden Realm — Persephone / Regardie
+- **Aesthetic:** Orchids veined with circuitry; pools of black water; violet rebirth sky.
+- **Beings:** Persephone’s shade; Regardie’s anima guides; orchid nymphs; daimonic bees.
+- **Mood:** Erotic Rebirth & Initiation — grief transfigured into renewal.
+- **Function:** Underworld Garden — descent, grief integration, sensual reclamation.
+- **Correspondence:** Pluto Gate.
+- **Stylepack:** `rosicrucian_black` + `druidic_greenman`.
+- **Fusion Code:** A + C = Visionary + Elite = Mystic Couture.
+- **ND-Safe Cue:** Low-bass violet pad (639 Hz), soft bloom, no strobe.
+
+## Tavern Realm — Shadow Academia
+- **Aesthetic:** Neon sigil lanterns; oak benches carved with glyphs; smoky alcoves.
+- **Beings:** Trenchcoat mystics; occult scholars; shadow-seers.
+- **Mood:** Smoky, Sensual, Secret Knowledge.
+- **Function:** Crossroads — covenant-drafting, paradox debates, forbidden lore.
+- **Correspondence:** Mercury Gate.
+- **Stylepack:** `rosslyn_gothic`.
+- **Fusion Code:** B + C = Occult Editorial.
+- **ND-Safe Cue:** Jazz-low hum (417 Hz) with lantern glow (no flicker).
+
+---
+These three Realms form narrative portals of Order, Death-Rebirth, and Secret Lore, binding architecture, mood, beings, and function as archetypal initiations parallel to the Frequency Realms.

--- a/cathedral.html
+++ b/cathedral.html
@@ -14,6 +14,8 @@
   <link rel="stylesheet" href="./assets/css/palette.css">
   <link rel="stylesheet" href="./assets/css/light.css">
   <link rel="stylesheet" href="/assets/css/perm-style.css" />
+  <link rel="stylesheet" href="./assets/css/meta_realms.css">
+  <link rel="stylesheet" href="./assets/css/cathedral_icon.css">
 <script src="/bridge/c99-bridge.js" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
@@ -94,6 +96,27 @@
 
     <section class="room" id="room-info" aria-live="polite">
       <strong>Realm:</strong> Nave • <strong>Tone:</strong> 432 Hz • <strong>Overlay:</strong> stone-angels.png
+    </section>
+
+    <section id="meta-realms">
+      <h2>Meta Realms</h2>
+      <ul class="realms-list">
+        <li class="realm realm--temple">
+          <span class="icon-seal icon-seal--temple" aria-hidden="true"></span>
+          <strong>Temple Realm — Cathedral of Circuits™.</strong>
+          Neon stained glass lattices and algorithmic Thrones.
+        </li>
+        <li class="realm realm--garden">
+          <span class="icon-seal icon-seal--garden" aria-hidden="true"></span>
+          <strong>Garden Realm — Persephone / Regardie.</strong>
+          Orchids veined with circuitry and pools of black water.
+        </li>
+        <li class="realm realm--tavern">
+          <span class="icon-seal icon-seal--tavern" aria-hidden="true"></span>
+          <strong>Tavern Realm — Shadow Academia.</strong>
+          Neon sigil lanterns and smoky alcoves of forbidden lore.
+        </li>
+      </ul>
     </section>
 
   </main>


### PR DESCRIPTION
## Summary
- Fill "Cathedral of Circuits" chapter with Temple, Garden, and Tavern realm descriptions
- Style Meta Realms and icon seals, adding base and variant cathedral seal SVGs
- Extend cathedral nave with Meta Realms section and related styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b91dc920b4832888d5deb9df2b2079