### PR TITLE
Add shared visionary palette

### DIFF
--- a/data/palettes/visionary.json
+++ b/data/palettes/visionary.json
@@ -1,0 +1,20 @@
+{
+  "visionary": {
+    "core": {
+      "indigo": "#280050",
+      "violet": "#460082",
+      "blue": "#0080FF",
+      "green": "#00FF80",
+      "amber": "#FFC800",
+      "light": "#FFFFFF"
+    },
+    "secondary": {
+      "crimson": "#B7410E",
+      "gold": "#FFD700",
+      "slate": "#2E2E2E",
+      "silver": "#C0C0C0",
+      "sky": "#87CEFA",
+      "shadow": "#4B0082"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add visionary palette JSON for core and secondary colors

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9237131a48328a7f1a7fae61ff47a