### PR TITLE
feat(style+world): couture pearlescent update, Avalon flavor and ward sigil

### DIFF
--- a/assets/css/perm-style.css
+++ b/assets/css/perm-style.css
@@ -63,3 +63,39 @@ h3{font-size:var(--scale-h3)}
 @media (prefers-reduced-motion:reduce){
   *{animation:none !important; transition:none !important}
 }
+
+/* violet gate + respawn gate */
+.violet-gate,.respawn-gate{
+  width:200px;height:200px;border-radius:50%;
+  border:var(--line-pillar) solid var(--grail_gold,var(--gold));
+  background:radial-gradient(circle at center,var(--violet_core,var(--violet)) 0%,var(--void) 100%);
+}
+.violet-gate.bg-soft,.respawn-gate.bg-soft{
+  background:radial-gradient(circle at center,rgba(110,0,255,.2)0%,transparent 80%);
+}
+
+/* oracle velvet */
+.oracle-velvet{background:linear-gradient(145deg,var(--gonz-1),var(--gonz-3));color:var(--bone);}
+
+/* luminous heart backdrop */
+.luminous-heart{background:radial-gradient(circle at 50% 30%,rgba(255,255,255,.3),transparent 70%),var(--violet_aura,var(--violet));}
+
+/* avalon grove */
+.avalon-grove{background:linear-gradient(180deg,var(--avalon_mist),var(--avalon_night));color:var(--bone);}
+
+/* between realm narthex */
+.between-narthex{background:rgba(0,0,0,.6);backdrop-filter:blur(2px);}
+body.allow-motion .between-narthex[data-drift="on"]{animation:veil-drift 40s linear infinite;}
+@keyframes veil-drift{from{background-position:0 0;}to{background-position:1000px 0;}}
+
+/* flavor chips */
+.mode-rail{display:flex;gap:.5rem;flex-wrap:wrap;}
+.mode-chip,.solfeggio-chip{padding:.25rem .5rem;border-radius:.25rem;background:var(--ink);border:1px solid var(--gold);font-size:.75rem;}
+
+/* oracle + angel cards */
+.egregore-card,.consecration-angel{border:var(--line-primary) solid var(--gold_leaf,var(--gold));padding:1rem;background:var(--ink);}
+
+/* protection handsigil */
+.protection-handsigil{--size:80px;width:var(--size);height:var(--size);border-radius:40% 40% 35% 35%;background:var(--nacre_pearl,#f0ead6);position:relative;}
+.protection-handsigil::before{content:"";position:absolute;top:15%;left:20%;width:60%;height:60%;border-radius:50%;background:var(--teal_glow);box-shadow:0 0 0 4px var(--gold);}
+.protection-handsigil::after{content:"";position:absolute;top:8%;left:30%;width:40%;height:20%;border-top-left-radius:50% 100%;border-top-right-radius:50% 100%;background:var(--gold);}

--- a/assets/tokens/perm-style.json
+++ b/assets/tokens/perm-style.json
@@ -1,14 +1,14 @@
 {
   "meta": {
     "name": "Circuitum99 -- Perm Style",
-    "version": "1.0.0",
+    "version": "3.7.0",
     "source": [
       "data/visionary.json",
       "docs/style/palette.json",
       "cosmogenesis/registry/datasets/palettes.core.json"
     ],
     "nd_safe": true,
-    "notes": "No autoplay, no strobe. High-end couture × ancient arcana."
+    "notes": "World-of-Enchantment baseline; Avalon fixed; Aeons flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven ward; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer."
   },
   "palette": {
     "void": "#0B0B0B",
@@ -29,7 +29,41 @@
     "teal_glow": "#00CED1",
     "violet_alt": "#8A2BE2",
 
-    "gonzalez_palette": ["#0b0b0b", "#16121b", "#2a2140", "#5e4ba8", "#e6e6e6"]
+    "gonzalez_palette": ["#0b0b0b", "#16121b", "#2a2140", "#5e4ba8", "#e6e6e6"],
+
+    "obsidian_glass": "#1c1c1c",
+    "obsidian_sheen": "#2e2e2e",
+    "obsidian_rainbow": "#545455",
+    "shungite": "#252525",
+    "tourmaline": "#1b2e34",
+    "basalt": "#2d2d30",
+    "glint_silver": "#d9dfe4",
+    "lava_ember": "#ff4500",
+    "lava_core": "#b22222",
+    "raku_copper": "#b87333",
+    "raku_charcoal": "#333333",
+    "raku_violet": "#6a0dad",
+    "raku_azure": "#007fff",
+    "gold_leaf": "#d4af37",
+    "gold_leaf_warm": "#ffcc66",
+    "gold_leaf_cold": "#c0c080",
+    "nacre_pearl": "#f0ead6",
+    "moonstone": "#e0e4f3",
+    "moonstone_glow": "#cfd8dc",
+    "abalone_shell": "#7fffd4",
+    "avalon_mist": "#ccd6d9",
+    "avalon_night": "#1a1a2e",
+    "tor_stone": "#8e8e83",
+    "isle_reed": "#6b8e23",
+    "astral_dusk": "#4b0082",
+    "astral_dawn": "#ffefd5",
+    "starlight_silver": "#f8f8ff",
+    "starlight_gold": "#fff8dc",
+    "violet_core": "#8a2be2",
+    "violet_flare": "#bf00ff",
+    "violet_smoke": "#551a8b",
+    "violet_aura": "#c9a0dc",
+    "grail_gold": "#e4c580"
   },
   "line": {
     "hair": 1,
@@ -48,6 +82,81 @@
     "pillars_21": true,
     "gates_99": true
   },
+  "layers": {
+    "visionary": "visionary-grid",
+    "rakuPatina": "raku-patina",
+    "goldLeaf": "goldLeaf",
+    "pearl": "nacre",
+    "moonstone": "adularescence",
+    "abalone": "abalone-shell",
+    "gonzVelvet": "oracle-velvet",
+    "faeShimmer": "true-fairy",
+    "roseGate": "roseGate",
+    "violetFlame": "violetFlame",
+    "violetGate": "violetGate",
+    "respawnGate": "respawnGate",
+    "avalonGrove": "avalonGrove",
+    "inBetweenVeil": "inBetweenVeil",
+    "trueFairy": "trueFairy",
+    "protectionSigil": "protectionSigil"
+  },
+  "materials": {
+    "volcanic_obsidian": ["obsidian_glass","obsidian_sheen","obsidian_rainbow"],
+    "shungite": ["shungite","tourmaline","basalt","glint_silver"],
+    "raku_lineage": ["raku_copper","raku_charcoal","raku_violet","raku_azure"],
+    "gold_leaf": ["gold_leaf","gold_leaf_warm","gold_leaf_cold"],
+    "mother_of_pearl": ["nacre_pearl"],
+    "moonstone": ["moonstone","moonstone_glow"],
+    "abalone": ["abalone_shell"]
+  },
+  "effects": {
+    "stars": "twinkle",
+    "ember_eyes": true
+  },
+  "healing": {
+    "solfeggio": {
+      "396": "liberation from fear",
+      "417": "transmutation",
+      "528": "miracles",
+      "639": "relationships",
+      "741": "awaken intuition",
+      "852": "return to spirit",
+      "963": "oneness"
+    },
+    "biogeometry_angles": [27,36,45,63,81]
+  },
+  "avatars": {
+    "incarnate_self": "Incarnate Self",
+    "rebecca_respawn": {"name":"Rebecca Respawn","numerology":11},
+    "drag_persona": {"name":"Drag Persona","numerology":22},
+    "virelai_ezra_lux": {"name":"Virelai Ezra Lux","numerology":33,"note":"Lavender Quan Yin Reiki"}
+  },
+  "avalon": {
+    "current":"Priestess",
+    "service":"Grail",
+    "tor_isle_polarity":true,
+    "round_table_oath":true,
+    "veils":["Outer Isle","Inner Sanctuary","Lady's Veil"]
+  },
+  "between_realm": {
+    "name":"In-Between Astral Narthex",
+    "liminal":"veil eddies and star-motes"
+  },
+  "adventure_modes": {
+    "hermetic_alchemy":["nigredo","albedo","citrinitas","rubedo"],
+    "tree_of_life":{"sephiroth":10,"paths":22},
+    "theosophical_aeons":["Sat","Svabhavat","Manvantara","Pralaya","Rounds","Root-Races"]
+  },
+  "rituals": {
+    "violet_flame": {
+      "steps":["Invoke","Rotate","Transmute","Replace"],
+      "alias":"respawnGate",
+      "ray":"VI"
+    }
+  },
+  "angels": { "consecration": 72 },
+  "pillars": { "columns":["Severity","Mildness","Mercy"], "levels":7 },
+  "egregores": { "ray":"VI", "pillar":"middle" },
   "a11y": {
     "min_contrast": 4.5,
     "motion": "reduce",

--- a/bridge/c99-bridge.json
+++ b/bridge/c99-bridge.json
@@ -1,9 +1,9 @@
 {
   "meta": {
     "project": "Circuitum99 × Stone Grimoire",
-    "updated": "2025-09-02T14:00:00Z",
+    "updated": "2025-09-04T06:25:42.678Z",
     "nd_safe": true,
-    "generator": "manual seed"
+    "generator": "update-art.js"
   },
   "tokens": {
     "css": "/assets/css/perm-style.css",
@@ -18,7 +18,106 @@
       "green": "#00FF80",
       "amber": "#FFC800",
       "light": "#FFFFFF",
-      "gold": "#C9A227"
+      "crimson": "#B7410E",
+      "gold": "#C9A227",
+      "obsidian": "#0B0B0B",
+      "rose_quartz": "#FFB6C1",
+      "teal_glow": "#00CED1",
+      "violet_alt": "#8A2BE2",
+      "gonzalez_palette": [
+        "#0b0b0b",
+        "#16121b",
+        "#2a2140",
+        "#5e4ba8",
+        "#e6e6e6"
+      ],
+      "obsidian_glass": "#1c1c1c",
+      "obsidian_sheen": "#2e2e2e",
+      "obsidian_rainbow": "#545455",
+      "shungite": "#252525",
+      "tourmaline": "#1b2e34",
+      "basalt": "#2d2d30",
+      "glint_silver": "#d9dfe4",
+      "lava_ember": "#ff4500",
+      "lava_core": "#b22222",
+      "raku_copper": "#b87333",
+      "raku_charcoal": "#333333",
+      "raku_violet": "#6a0dad",
+      "raku_azure": "#007fff",
+      "gold_leaf": "#d4af37",
+      "gold_leaf_warm": "#ffcc66",
+      "gold_leaf_cold": "#c0c080",
+      "nacre_pearl": "#f0ead6",
+      "moonstone": "#e0e4f3",
+      "moonstone_glow": "#cfd8dc",
+      "abalone_shell": "#7fffd4",
+      "avalon_mist": "#ccd6d9",
+      "avalon_night": "#1a1a2e",
+      "tor_stone": "#8e8e83",
+      "isle_reed": "#6b8e23",
+      "astral_dusk": "#4b0082",
+      "astral_dawn": "#ffefd5",
+      "starlight_silver": "#f8f8ff",
+      "starlight_gold": "#fff8dc",
+      "violet_core": "#8a2be2",
+      "violet_flare": "#bf00ff",
+      "violet_smoke": "#551a8b",
+      "violet_aura": "#c9a0dc",
+      "grail_gold": "#e4c580"
+    },
+    "secondary": {},
+    "layers": {
+      "visionary": "visionary-grid",
+      "rakuPatina": "raku-patina",
+      "goldLeaf": "goldLeaf",
+      "pearl": "nacre",
+      "moonstone": "adularescence",
+      "abalone": "abalone-shell",
+      "gonzVelvet": "oracle-velvet",
+      "faeShimmer": "true-fairy",
+      "roseGate": "roseGate",
+      "violetFlame": "violetFlame",
+      "violetGate": "violetGate",
+      "respawnGate": "respawnGate",
+      "avalonGrove": "avalonGrove",
+      "inBetweenVeil": "inBetweenVeil",
+      "trueFairy": "trueFairy",
+      "protectionSigil": "protectionSigil"
+    },
+    "adventure_modes": {
+      "hermetic_alchemy": [
+        "nigredo",
+        "albedo",
+        "citrinitas",
+        "rubedo"
+      ],
+      "tree_of_life": {
+        "sephiroth": 10,
+        "paths": 22
+      },
+      "theosophical_aeons": [
+        "Sat",
+        "Svabhavat",
+        "Manvantara",
+        "Pralaya",
+        "Rounds",
+        "Root-Races"
+      ]
+    },
+    "avalon": {
+      "current": "Priestess",
+      "service": "Grail",
+      "tor_isle_polarity": true,
+      "round_table_oath": true,
+      "veils": [
+        "Outer Isle",
+        "Inner Sanctuary",
+        "Lady's Veil"
+      ]
+    },
+    "between_realm": {
+      "name": "In-Between Astral Narthex",
+      "liminal": "veil eddies and star-motes"
     }
   },
   "routes": {
@@ -43,22 +142,7 @@
       "tone": 110,
       "geometry": "vesica",
       "stylepack": "Rosicrucian Black",
-      "assets": [
-        {
-          "name": "portal_crypt-a01.png",
-          "thumb": "/assets/art/thumbs/portal_crypt-a01-512.jpg",
-          "webp": "/assets/art/webp/portal_crypt-a01.webp",
-          "src": "/assets/art/processed/portal_crypt-a01.png",
-          "type": "png"
-        },
-        {
-          "name": "sigil_ann-abyss.svg",
-          "thumb": "",
-          "webp": "",
-          "src": "/assets/art/processed/sigil_ann-abyss.svg",
-          "type": "svg"
-        }
-      ]
+      "assets": []
     },
     {
       "id": "nave",
@@ -67,15 +151,7 @@
       "tone": 222,
       "geometry": "rose-window",
       "stylepack": "Angelic Chorus",
-      "assets": [
-        {
-          "name": "portal_nave-a02.png",
-          "thumb": "/assets/art/thumbs/portal_nave-a02-512.jpg",
-          "webp": "/assets/art/webp/portal_nave-a02.webp",
-          "src": "/assets/art/processed/portal_nave-a02.png",
-          "type": "png"
-        }
-      ]
+      "assets": []
     },
     {
       "id": "apprentice_pillar",
@@ -84,15 +160,7 @@
       "tone": 333,
       "geometry": "fibonacci",
       "stylepack": "Hilma Spiral",
-      "assets": [
-        {
-          "name": "border_apprentice.svg",
-          "thumb": "",
-          "webp": "",
-          "src": "/assets/art/processed/border_apprentice.svg",
-          "type": "svg"
-        }
-      ]
+      "assets": []
     },
     {
       "id": "respawn_gate",
@@ -101,75 +169,556 @@
       "tone": 432,
       "geometry": "merkaba",
       "stylepack": "Alchemical Bloom",
-      "assets": [
-        {
-          "name": "portal_respawn-a01.png",
-          "thumb": "/assets/art/thumbs/portal_respawn-a01-512.jpg",
-          "webp": "/assets/art/webp/portal_respawn-a01.webp",
-          "src": "/assets/art/processed/portal_respawn-a01.png",
-          "type": "png"
-        }
-      ]
+      "assets": []
     }
   ],
-  "angels": [
-    {
-      "id": "angel-01",
-      "name": "Vehuiah",
-      "virtue": "Initiation",
-      "seal": "/assets/art/processed/seal_gate-01.svg",
-      "gate": 1
-    },
-    {
-      "id": "angel-02",
-      "name": "Jeliel",
-      "virtue": "Union",
-      "seal": "/assets/art/processed/seal_gate-02.svg",
-      "gate": 2
-    },
-    {
-      "id": "angel-03",
-      "name": "Sitael",
-      "virtue": "Refuge",
-      "seal": "/assets/art/processed/seal_gate-03.svg",
-      "gate": 3
-    },
-    {
-      "id": "angel-04",
-      "name": "Elemiah",
-      "virtue": "Orientation",
-      "seal": "/assets/art/processed/seal_gate-04.svg",
-      "gate": 4
-    }
-  ],
+  "angels": [],
+  "creatures": {
+    "dragons": [],
+    "daimons": []
+  },
+  "visionary": {
+    "overlays": []
+  },
+  "oracle": [],
+  "angel_assets": [],
+  "pillars": [],
+  "egregores": [],
+  "between_realm": {
+    "name": "In-Between Astral Narthex",
+    "liminal": "veil eddies and star-motes",
+    "assets": []
+  },
   "assets": [
     {
-      "name": "portal_crypt-a01.png",
-      "src": "/assets/art/processed/portal_crypt-a01.png",
-      "thumb": "/assets/art/thumbs/portal_crypt-a01-512.jpg",
-      "webp": "/assets/art/webp/portal_crypt-a01.webp",
-      "type": "png"
-    },
-    {
-      "name": "sigil_ann-abyss.svg",
-      "src": "/assets/art/processed/sigil_ann-abyss.svg",
+      "name": "circuitum99_linkedin_square1080.jpeg",
+      "src": "/assets/art/processed/circuitum99_linkedin_square1080.jpeg",
       "thumb": "",
       "webp": "",
-      "type": "svg"
+      "type": "jpeg"
     },
     {
-      "name": "portal_nave-a02.png",
-      "src": "/assets/art/processed/portal_nave-a02.png",
-      "thumb": "/assets/art/thumbs/portal_nave-a02-512.jpg",
-      "webp": "/assets/art/webp/portal_nave-a02.webp",
+      "name": "img_2539.jpeg",
+      "src": "/assets/art/processed/img_2539.jpeg",
+      "thumb": "",
+      "webp": "",
+      "type": "jpeg"
+    },
+    {
+      "name": "img_2608.webp",
+      "src": "/assets/art/processed/img_2608.webp",
+      "thumb": "",
+      "webp": "",
+      "type": "webp"
+    },
+    {
+      "name": "img_2609.webp",
+      "src": "/assets/art/processed/img_2609.webp",
+      "thumb": "",
+      "webp": "",
+      "type": "webp"
+    },
+    {
+      "name": "img_2642.png",
+      "src": "/assets/art/processed/img_2642.png",
+      "thumb": "",
+      "webp": "",
       "type": "png"
     },
     {
-      "name": "portal_respawn-a01.png",
-      "src": "/assets/art/processed/portal_respawn-a01.png",
-      "thumb": "/assets/art/thumbs/portal_respawn-a01-512.jpg",
-      "webp": "/assets/art/webp/portal_respawn-a01.webp",
+      "name": "iro-color.png",
+      "src": "/assets/art/processed/iro-color.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "banner_grimoire_serious.png",
+      "src": "/assets/art/processed/banner_grimoire_serious.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-10.png",
+      "src": "/assets/art/processed/photo-10.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-11.png",
+      "src": "/assets/art/processed/photo-11.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-12.png",
+      "src": "/assets/art/processed/photo-12.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-13.png",
+      "src": "/assets/art/processed/photo-13.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-14.png",
+      "src": "/assets/art/processed/photo-14.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-15.png",
+      "src": "/assets/art/processed/photo-15.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-16.png",
+      "src": "/assets/art/processed/photo-16.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-17.png",
+      "src": "/assets/art/processed/photo-17.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-18.png",
+      "src": "/assets/art/processed/photo-18.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-19.png",
+      "src": "/assets/art/processed/photo-19.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-2.png",
+      "src": "/assets/art/processed/photo-2.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-20.png",
+      "src": "/assets/art/processed/photo-20.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-21.png",
+      "src": "/assets/art/processed/photo-21.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-22.png",
+      "src": "/assets/art/processed/photo-22.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-23.png",
+      "src": "/assets/art/processed/photo-23.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-24.png",
+      "src": "/assets/art/processed/photo-24.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-25.png",
+      "src": "/assets/art/processed/photo-25.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-26.png",
+      "src": "/assets/art/processed/photo-26.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-27.png",
+      "src": "/assets/art/processed/photo-27.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-28.png",
+      "src": "/assets/art/processed/photo-28.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-29.png",
+      "src": "/assets/art/processed/photo-29.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-3.png",
+      "src": "/assets/art/processed/photo-3.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-30.png",
+      "src": "/assets/art/processed/photo-30.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-31.png",
+      "src": "/assets/art/processed/photo-31.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-32.png",
+      "src": "/assets/art/processed/photo-32.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-33.png",
+      "src": "/assets/art/processed/photo-33.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-34.png",
+      "src": "/assets/art/processed/photo-34.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-35.png",
+      "src": "/assets/art/processed/photo-35.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-36.png",
+      "src": "/assets/art/processed/photo-36.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-37.png",
+      "src": "/assets/art/processed/photo-37.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-38.png",
+      "src": "/assets/art/processed/photo-38.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-39.png",
+      "src": "/assets/art/processed/photo-39.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-4.png",
+      "src": "/assets/art/processed/photo-4.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-40.png",
+      "src": "/assets/art/processed/photo-40.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-41.png",
+      "src": "/assets/art/processed/photo-41.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-42.png",
+      "src": "/assets/art/processed/photo-42.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-43.png",
+      "src": "/assets/art/processed/photo-43.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-44.png",
+      "src": "/assets/art/processed/photo-44.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-45.png",
+      "src": "/assets/art/processed/photo-45.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-46.png",
+      "src": "/assets/art/processed/photo-46.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-47.png",
+      "src": "/assets/art/processed/photo-47.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-48.png",
+      "src": "/assets/art/processed/photo-48.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-49.png",
+      "src": "/assets/art/processed/photo-49.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-5.png",
+      "src": "/assets/art/processed/photo-5.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-50.png",
+      "src": "/assets/art/processed/photo-50.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-51.png",
+      "src": "/assets/art/processed/photo-51.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-52.png",
+      "src": "/assets/art/processed/photo-52.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-53.png",
+      "src": "/assets/art/processed/photo-53.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-54.png",
+      "src": "/assets/art/processed/photo-54.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-55.png",
+      "src": "/assets/art/processed/photo-55.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-56.png",
+      "src": "/assets/art/processed/photo-56.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-57.png",
+      "src": "/assets/art/processed/photo-57.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-58.png",
+      "src": "/assets/art/processed/photo-58.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-59.png",
+      "src": "/assets/art/processed/photo-59.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-6.png",
+      "src": "/assets/art/processed/photo-6.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-60.png",
+      "src": "/assets/art/processed/photo-60.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-61.png",
+      "src": "/assets/art/processed/photo-61.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-62.png",
+      "src": "/assets/art/processed/photo-62.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-63.png",
+      "src": "/assets/art/processed/photo-63.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-64.png",
+      "src": "/assets/art/processed/photo-64.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-65.png",
+      "src": "/assets/art/processed/photo-65.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-66.png",
+      "src": "/assets/art/processed/photo-66.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-67.png",
+      "src": "/assets/art/processed/photo-67.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-7.png",
+      "src": "/assets/art/processed/photo-7.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-8.png",
+      "src": "/assets/art/processed/photo-8.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo-9.png",
+      "src": "/assets/art/processed/photo-9.png",
+      "thumb": "",
+      "webp": "",
+      "type": "png"
+    },
+    {
+      "name": "photo.png",
+      "src": "/assets/art/processed/photo.png",
+      "thumb": "",
+      "webp": "",
       "type": "png"
     }
-  ]
+  ],
+  "rituals": {
+    "violet_flame": {
+      "alias": "respawnGate",
+      "ray": "VI",
+      "steps": [
+        "Invoke",
+        "Rotate",
+        "Transmute",
+        "Replace"
+      ]
+    }
+  }
 }

--- a/core/build/update-art.js
+++ b/core/build/update-art.js
@@ -48,7 +48,7 @@ async function main(){
   const angels72    = safeReadJSON(path.resolve(root,'../cosmogenesis-learning-engine/registry/datasets/angels72.json')) ||
                       safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/angels72.json')) ||
                       safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/shem72.json'));
-  const styleTokens = safeReadJSON(path.resolve(root,'assets','tokens','perm-style.json')) || { palette:{}, secondary:{}, layers:{} };
+  const styleTokens = safeReadJSON(path.resolve(root,'assets','tokens','perm-style.json')) || { palette:{}, secondary:{}, layers:{}, adventure_modes:{}, avalon:{}, between_realm:{} };
 
   const defaultRooms = [
     { id:"crypt", title:"The Crypt", element:"earth", stylepack:"Rosicrucian Black", tone:110, geometry:"vesica" },
@@ -100,11 +100,18 @@ async function main(){
   }
 
   const visionaryAssets = assets.filter(a => /alex[-_ ]?grey|visionary|sacred|grid/.test(a.name));
+  const oracleVelvet = assets.filter(a => /oracle|velvet/.test(a.name));
+  const angelArt = assets.filter(a => /angel/.test(a.name));
+  const pillarArt = assets.filter(a => /pillar/.test(a.name));
+  const egregoreArt = assets.filter(a => /egregore/.test(a.name));
+  const betweenAssets = assets.filter(a => /(between|narthex|veil|threshold)/.test(a.name));
+  const wardAssets = assets.filter(a => /(hamsa|evil[-_]?eye|logo|ward)/.test(a.name));
 
   const manifest = {
     meta:{ project:"Circuitum99 × Stone Grimoire", updated:new Date().toISOString(), nd_safe:true, generator:"update-art.js" },
     tokens:{ css:"/assets/css/perm-style.css", json:"/assets/tokens/perm-style.json",
-      palette:styleTokens.palette||{}, secondary:styleTokens.secondary||{}, layers:styleTokens.layers||{} },
+      palette:styleTokens.palette||{}, secondary:styleTokens.secondary||{}, layers:styleTokens.layers||{},
+      adventure_modes:styleTokens.adventure_modes||{}, avalon:styleTokens.avalon||{}, between_realm:styleTokens.between_realm||{} },
     routes:{
       stone_grimoire:{ base:"/", chapels:"/chapels/", assets:"/assets/", bridge:"/bridge/c99-bridge.json" },
       cosmogenesis:{ tokens:"/c99/tokens/perm-style.json", css:"/c99/css/perm-style.css", public:"/c99/", bridge:"/bridge/c99-bridge.json" }
@@ -113,10 +120,17 @@ async function main(){
       id:r.id, title:r.title, element:r.element, tone:r.tone, geometry:r.geometry, stylepack:r.stylepack,
       assets:(assetsByRoom[r.id]||[]).map(a => ({ name:a.name, thumb:`/${a.thumb}`, webp:a.webp?`/${a.webp}`:'', src:`/${a.processed}`, type:a.type }))
     })),
-    angels, creatures,
-    visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-    assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type }))
-  };
+      angels, creatures,
+      visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
+      oracle: oracleVelvet.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
+      angel_assets: angelArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
+      pillars: pillarArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
+      egregores: egregoreArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
+      between_realm:{ ...(styleTokens.between_realm||{}), assets: betweenAssets.map(a => ({ name:a.name, class:'between-narthex', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
+      protection: wardAssets.length?{ sigil: wardAssets.map(a => ({ name:a.name, class:'protection-handsigil', layer:'protectionSigil', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) }:undefined,
+      assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type })),
+      rituals:{ violet_flame:{ alias:'respawnGate', ray:'VI', steps:['Invoke','Rotate','Transmute','Replace'] } }
+    };
 
   const bridgeRoot = path.resolve(root, '../../bridge');
   fs.mkdirSync(bridgeRoot, {recursive:true});


### PR DESCRIPTION
## Summary
- expand permanent style tokens to version 3.7.0 with new palettes, layers, materials, healing info, and adventure modes
- append couture CSS utilities for violet gates, velvet panels, luminous hearts, Avalon scenes, narthex veils, flavor chips, oracle/angel cards, and protection hand sigil
- patch art ingest script to surface adventure modes, Avalon/between realm data, violet flame alias, ward detection, and asset grouping in the bridge manifest

## Testing
- `node core/build/update-art.js`


------
https://chatgpt.com/codex/tasks/task_e_68b930445e148328b0a88b5cf8a98798