### PR TITLE
Document Liber Arcanae tarot bridge

### DIFF
--- a/REGISTRY/tarot_system.md
+++ b/REGISTRY/tarot_system.md
@@ -13,6 +13,14 @@ Seal Motto: “In Codice Abyssiae, Angelus et Daemon concordant.”
 
 ⸻
 
+✦ Bridge to Codex 144:99
+    • The Liber Arcanae repository hosts the living tarot system and syncs with Codex 144:99.
+    • Each card maps to a codex node for lineage, tokens, and crystal data.
+    • bridge/c99-bridge.json carries shared palettes and stylepacks across repos.
+    • This link keeps the tarot deck alive as the codex expands.
+
+⸻
+
 ✦ Core Philosophy
     • The Tarot is a living Monad Hieroglyphica: Sun, Moon, Cross, and Spirit recombined into 78 glyphs.
     • Each card = a node: angel/demon, Ray, planet, crystal, daimon, Wetiko pattern, Tara emanation.


### PR DESCRIPTION
## Summary
- Document bridge section linking Liber Arcanae repository with Codex 144:99 tarot system

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc322a3c8328961319b5a00f9ef4