### PR TITLE
Normalize punctuation in JS engines

### DIFF
--- a/assets/js/engines/auto-chapel.js
+++ b/assets/js/engines/auto-chapel.js
@@ -82,7 +82,7 @@
   main.insertBefore(header, main.firstChild);
 
   // ===== Plaque + Ritual block (below header) =====
-  // If neither exists, we’re done (no extra DOM)
+  // If neither exists, we're done (no extra DOM)
   if (!plaque && !ritual) return;
 
   const block = document.createElement('section');

--- a/assets/js/engines/cosmic-axis-engine.js
+++ b/assets/js/engines/cosmic-axis-engine.js
@@ -5,7 +5,7 @@
  *
  * ──────────────────────────────────────────────────────────────────────────────
  * FEATURES
- * - Draws a celestial field on a tilted axis (default 23.5°) with ecliptic, meridians, Jacob’s Ladder spine,
+ * - Draws a celestial field on a tilted axis (default 23.5°) with ecliptic, meridians, Jacob's Ladder spine,
  *   rose/vesica tracery, and a logarithmic or Archimedean spiral node lattice (up to 144+ nodes).
  * - Palette aware (wash/ink/accent/gold). Works with your stylepacks.json (array or map).
  * - Modular overlays: I Ching hexagram bands, numerology resonance, planetary tints (gentle).
@@ -224,7 +224,7 @@ function drawCosmos(ctx, cfg, tClock = 0) {
     }
   }
 
-  // Ladder spine (Jacob’s)
+  // Ladder spine (Jacob's)
   if (overlays.drawLadder) {
     ctx.strokeStyle = blend(palette.accent, "#000000", 0.25);
     ctx.lineWidth = 2;

--- a/assets/js/engines/planetary-light.js
+++ b/assets/js/engines/planetary-light.js
@@ -90,7 +90,7 @@ function hexA(hex, a){
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
-// Event wiring: listen for your app’s custom events.
+// Event wiring: listen for your app's custom events.
 function onAngelActivate(e){ applyAngel(e.detail || {}); }
 function onSignSet(e){ applySign((e.detail && e.detail.sign) || "Sun"); }
 

--- a/core/build/generate-seal.js
+++ b/core/build/generate-seal.js
@@ -77,7 +77,7 @@ push(`<defs>
 push(`<rect x="0" y="0" width="${W}" height="${H}" fill="url(#bgGrad)"/>`);
 push(`<circle cx="${CX}" cy="${CY}" r="${R_OUT+60}" fill="none" stroke="${EDGE}" stroke-width="18"/>`);
 
-// OUTER RING — 78 gates (22 Hebrew + 56 minors)
+// OUTER RING - 78 gates (22 Hebrew + 56 minors)
 const GATES = 78, stepGate = 360/GATES;
 for(let i=0;i<GATES;i++){
   const ang = -90 + i*stepGate;
@@ -97,7 +97,7 @@ for(let i=0;i<GATES;i++){
   }
 }
 
-// SECOND RING — 72 Shem alternating with 72 Goetia (144 ticks)
+// SECOND RING - 72 Shem alternating with 72 Goetia (144 ticks)
 const marks = 144, stepMark = 360/marks;
 for(let i=0;i<marks;i++){
   const a = -90 + i*stepMark;
@@ -115,7 +115,7 @@ for(let i=0;i<marks;i++){
   }
 }
 
-// THIRD RING — 33 beads (alchemical sequence), Ars Notoria notae at 11/22/33
+// THIRD RING - 33 beads (alchemical sequence), Ars Notoria notae at 11/22/33
 const BEADS = 33, stepB = 360/BEADS;
 for(let i=0;i<BEADS;i++){
   const a = -90 + i*stepB;
@@ -127,7 +127,7 @@ for(let i=0;i<BEADS;i++){
   }
 }
 
-// HEXAGRAM OF BLACK FLAMES — planetary archangels
+// HEXAGRAM OF BLACK FLAMES - planetary archangels
 const pts = [];
 for(let k=0;k<6;k++){ pts.push(polar(CX,CY,R_HEX, -90 + k*60)); }
 for(let k=0;k<6;k++){
@@ -142,7 +142,7 @@ PLAN.forEach((p,i)=>{
   push(`<text x="${px}" y="${py+8}" font-family="Junicode,serif" font-size="28" text-anchor="middle" fill="${INK}">${esc(p.glyph)}</text>`);
 });
 
-// CENTER — Vesica + Monad × LuxCrux fusion
+// CENTER - Vesica + Monad × LuxCrux fusion
 push(`<g>
   <ellipse cx="${CX-80}" cy="${CY}" rx="${R_VESICA}" ry="${R_VESICA*0.82}" fill="none" stroke="${SILV}" stroke-width="6"/>
   <ellipse cx="${CX+80}" cy="${CY}" rx="${R_VESICA}" ry="${R_VESICA*0.82}" fill="none" stroke="${SILV}" stroke-width="6"/>
@@ -161,8 +161,8 @@ push(`<g>
   <path d="M ${CX-180} ${CY-180} L ${CX+180} ${CY+180} M ${CX+180} ${CY-180} L ${CX-180} ${CY+180}" stroke="${AZURE}" stroke-width="4" stroke-opacity=".7"/>
 </g>`);
 
-// HIDDEN SPIRAL — Soyga + Ars Notoria (faint)
-const SOYGA = "ABHORSEMEM…SOYGA".split(''); // placeholder letter stream; replace if dataset exists
+// HIDDEN SPIRAL - Soyga + Ars Notoria (faint)
+const SOYGA = "ABHORSEMEM...SOYGA".split(''); // placeholder letter stream; replace if dataset exists
 const turns = 3.5, ptsSpiral = 220, r0 = 260, r1 = 60;
 for(let i=0;i<ptsSpiral;i++){
   const t = i/(ptsSpiral-1);


### PR DESCRIPTION
## Summary
- Replace smart quotes with ASCII quotes across browser JS engines
- Swap em dashes and ellipsis in generate-seal script for standard hyphen and dots

## Testing
- `node core/build/generate-seal.js`
- `node --check assets/js/engines/planetary-light.js`
- `node --check assets/js/engines/auto-chapel.js`
- `node --check assets/js/engines/cosmic-axis-engine.js`
- `python visionary_dream.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pillow` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0314e20c83288305c42c8eae92ca