### PR TITLE
feat: expand visionary art script

### DIFF
--- a/helpers/cathedral-helper.js
+++ b/helpers/cathedral-helper.js
@@ -67,7 +67,7 @@ export const CathedralHelper = (() => {
     return (light+0.05)/(dark+0.05);
   }
 
-  // ---------- ND‑safe audio (convolver + compressor + gain cap) ----------
+  // ---------- ND-safe audio (convolver + compressor + gain cap) ----------
   async function getCtx(){
     audioCtx = audioCtx || new (window.AudioContext||window.webkitAudioContext)();
     if (audioCtx.state !== 'running') await audioCtx.resume();

--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -1,41 +1,41 @@
 import numpy as np
 from PIL import Image
+import colorsys
 
 # Resolution of the output image
-WIDTH, HEIGHT = 1024, 1024
+WIDTH, HEIGHT = 1920, 1080
 
-# Generate coordinate grid centered at origin
-x = np.linspace(-1, 1, WIDTH)
-y = np.linspace(-1, 1, HEIGHT)
+# Generate coordinate grid spanning the aspect ratio
+x = np.linspace(-2, 2, WIDTH)
+y = np.linspace(-1.125, 1.125, HEIGHT)  # maintain 16:9 aspect
 X, Y = np.meshgrid(x, y)
 
-# Radial distance and angle for polar patterns
+# Convert to polar coordinates for radial symmetry
 R = np.sqrt(X**2 + Y**2)
 T = np.arctan2(Y, X)
 
-# Layered trigonometric pattern for visionary geometry
-pattern = np.sin(10 * R + 5 * np.sin(5 * T)) + np.cos(15 * T)
+# Layered trigonometric waves for visionary geometry
+layer1 = np.sin(6 * R - 3 * T)
+layer2 = np.cos(8 * T + 5 * R)
+layer3 = np.sin(4 * R + np.cos(12 * T))
+pattern = layer1 + layer2 + layer3
 
-# Normalize pattern to [0, 1]
+# Normalize combined pattern to [0, 1]
 pattern_norm = (pattern - pattern.min()) / (pattern.max() - pattern.min())
 
-# Map normalized values to a psychedelic color palette inspired by Alex Grey
-# Hue varies with pattern, saturation full, value based on radial distance
+# Map to HSV palette inspired by Alex Grey's luminous hues
 HSV = np.zeros((HEIGHT, WIDTH, 3), dtype=np.float32)
-HSV[..., 0] = pattern_norm  # hue
-HSV[..., 1] = 1.0           # saturation
-HSV[..., 2] = np.clip(1 - R, 0, 1)  # value gradient from center
+HSV[..., 0] = (pattern_norm + T / (2 * np.pi)) % 1.0  # hue cycles with angle
+HSV[..., 1] = 1.0                                        # full saturation
+HSV[..., 2] = np.clip(1 - R / 2, 0, 1)                   # radial value fade
 
 # Convert HSV to RGB
-import colorsys
 RGB = np.zeros_like(HSV)
 for i in range(HEIGHT):
     for j in range(WIDTH):
         RGB[i, j] = colorsys.hsv_to_rgb(*HSV[i, j])
 
-# Convert to 8-bit color and create image
+# Create and save the final artwork
 img = Image.fromarray((RGB * 255).astype(np.uint8))
-
-# Save the generated artwork
 img.save("Visionary_Dream.png")
 print("Visionary_Dream.png saved")


### PR DESCRIPTION
## Summary
- layer trigonometric waves and luminous hues for visionary art
- increase resolution and save output as Visionary_Dream.png
- replace non-breaking hyphen in helper script

## Testing
- `python3 visionary_dream.py` *(fails: No module named 'numpy')*
- `node -e "import('./helpers/cathedral-helper.js').then(()=>console.log('loaded')).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_68b9f88467708328b90a4efc76bdc87c