### PR TITLE
Add offline cosmic helix renderer

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -1,0 +1,20 @@
+# Cosmic Helix Renderer
+
+Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view.
+
+## Layers
+1. **Vesica field** – intersecting circles establishing the sacred lens.
+2. **Tree-of-Life scaffold** – 10 sephirot and 22 paths drawn with calm symmetry.
+3. **Fibonacci curve** – static log spiral approximated with 99 points.
+4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
+
+## Palette
+Colors are loaded from `data/palette.json`. If that file is missing, the renderer falls back to a safe default palette.
+
+## ND-Safe Choices
+- No animation, motion, or autoplay.
+- High-contrast yet soft color palette.
+- Simple ES module with no network requests.
+
+## Usage
+Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features.

--- a/helix-renderer/data/palette.json
+++ b/helix-renderer/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -1,0 +1,159 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine strands)
+*/
+
+// Small, pure, parameterized functions only; no animation, no external deps.
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+// L1 Vesica field: soft intersecting circles, gentle grid
+function drawVesica(ctx, w, h, color, NUM) {
+  const r = Math.min(w, h) / NUM.THREE; // radius tied to numerology
+  const cx = w / 2;
+  const cy = h / 2;
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
+  ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // subtle vesica grid using SEVEN lines for calm symmetry
+  ctx.lineWidth = 1;
+  const step = r / NUM.SEVEN;
+  ctx.beginPath();
+  for (let i = -NUM.SEVEN; i <= NUM.SEVEN; i++) {
+    const x = cx + i * step;
+    ctx.moveTo(x, cy - r);
+    ctx.lineTo(x, cy + r);
+  }
+  ctx.stroke();
+}
+
+// L2 Tree-of-Life: 10 nodes + 22 paths (NUM.TWENTYTWO)
+function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
+  const stepY = h / NUM.ELEVEN; // vertical rhythm
+  const xCenter = w / 2;
+  const xOffset = w / NUM.THREE / 2; // three pillars
+
+  const nodes = [
+    { x: xCenter, y: stepY }, // 0 Keter
+    { x: xCenter + xOffset, y: stepY * 2 }, // 1 Chokmah
+    { x: xCenter - xOffset, y: stepY * 2 }, // 2 Binah
+    { x: xCenter + xOffset, y: stepY * 4 }, // 3 Chesed
+    { x: xCenter - xOffset, y: stepY * 4 }, // 4 Geburah
+    { x: xCenter, y: stepY * 5 }, // 5 Tiphareth
+    { x: xCenter + xOffset, y: stepY * 7 }, // 6 Netzach
+    { x: xCenter - xOffset, y: stepY * 7 }, // 7 Hod
+    { x: xCenter, y: stepY * 8 }, // 8 Yesod
+    { x: xCenter, y: stepY * 10 }, // 9 Malkuth
+  ];
+
+  const paths = [
+    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
+    [5, 6], [5, 7], [6, 7], [6, 8], [7, 8], [8, 9], [5, 8], [1, 5],
+    [2, 5], [3, 6], [4, 7], [1, 6], [2, 7], [0, 5], // 22 paths
+  ];
+
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 1;
+  for (const [a, b] of paths) {
+    const p1 = nodes[a];
+    const p2 = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.stroke();
+  }
+
+  const r = Math.min(w, h) / NUM.THREE / NUM.ELEVEN; // small node radius
+  ctx.fillStyle = nodeColor;
+  for (const n of nodes) {
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// L3 Fibonacci curve: static polyline log spiral
+function drawFibonacci(ctx, w, h, color, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
+  const centerX = w / 2;
+  const centerY = h / 2;
+  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i <= NUM.NINETYNINE; i++) {
+    const angle = i * (Math.PI / NUM.ELEVEN); // gentle sweep
+    const r = scale * Math.pow(phi, i / NUM.NINE);
+    const x = centerX + r * Math.cos(angle);
+    const y = centerY + r * Math.sin(angle);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+// L4 Double-helix lattice: two phase-shifted sine waves with 144 struts
+function drawHelix(ctx, w, h, strandColor, latticeColor, NUM) {
+  const centerY = h / 2;
+  const amp = h / NUM.THREE; // amplitude linked to threefold nature
+  const steps = NUM.ONEFORTYFOUR; // lattice count
+  const freq = NUM.THREE; // three full twists
+
+  // vertical struts connecting the two strands
+  ctx.strokeStyle = latticeColor;
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= steps; i++) {
+    const x = (w / steps) * i;
+    const phase = (i / steps) * freq * Math.PI;
+    const y1 = centerY + amp * Math.sin(phase);
+    const y2 = centerY + amp * Math.sin(phase + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+
+  // first strand
+  ctx.strokeStyle = strandColor;
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const x = (w / steps) * i;
+    const phase = (i / steps) * freq * Math.PI;
+    const y = centerY + amp * Math.sin(phase);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // second strand phase-shifted by PI
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const x = (w / steps) * i;
+    const phase = (i / steps) * freq * Math.PI + Math.PI;
+    const y = centerY + amp * Math.sin(phase);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}


### PR DESCRIPTION
## Summary
- add ND-safe offline Cosmic Helix renderer with layered vesica, Tree-of-Life, Fibonacci, and double-helix lattice
- include palette data and documentation

## Testing
- `./scripts/check.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d5474148328a6f4b6cb98dd39dd