### PR TITLE
feat: render art without external deps

### DIFF
--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -1,45 +1,99 @@
-"""Generate a museum-quality visionary art piece inspired by Hilma af Klint."""
+"""Render a museum-quality visionary art piece inspired by Alex Grey."""
 
-# Import required libraries
-import numpy as np
-from PIL import Image
+# Import only standard library modules to avoid external dependencies
+import math
+import struct
+import zlib
 
-# Resolution of the output image (4K)
-WIDTH, HEIGHT = 3840, 2160
+# Canvas resolution (4K square)
+WIDTH, HEIGHT = 4096, 4096
 
-# Generate a coordinate grid centered at the canvas origin
-x = np.linspace(-1, 1, WIDTH)
-y = np.linspace(-1, 1, HEIGHT)
-X, Y = np.meshgrid(x, y)
+# Psychedelic palette inspired by Alex Grey (RGB 0-255)
+PALETTE = [
+    (255, 110, 0),   # vivid orange
+    (106, 0, 255),   # deep violet
+    (0, 255, 212),   # electric aqua
+    (255, 0, 133),   # neon magenta
+    (255, 255, 0),   # solar yellow
+]
 
-# Compute polar coordinates for radial symmetry
-R = np.sqrt(X**2 + Y**2)
-T = np.arctan2(Y, X)
+# Precompute coordinate scalars
+X_SCALE = 2 * math.pi / (WIDTH - 1)
+Y_SCALE = 2 * math.pi / (HEIGHT - 1)
+R_MAX = math.sqrt(2) * math.pi
 
-# Layered trigonometric pattern for visionary geometry
-pattern = np.sin(8 * R**2 + 6 * T) + np.cos(4 * R - 3 * T)
+# First pass: determine pattern range for normalization
+min_val, max_val = float("inf"), float("-inf")
+for j in range(HEIGHT):
+    ty = -math.pi + j * Y_SCALE
+    for i in range(WIDTH):
+        tx = -math.pi + i * X_SCALE
+        r = math.hypot(tx, ty)
+        t = math.atan2(ty, tx)
+        pattern = (
+            math.sin(3 * r) +
+            math.cos(5 * t) +
+            math.sin(2 * (tx + ty)) +
+            math.cos(2 * (tx - ty))
+        )
+        if pattern < min_val:
+            min_val = pattern
+        if pattern > max_val:
+            max_val = pattern
+range_val = max_val - min_val
 
-# Normalize pattern to the range [0, 1]
-pattern_norm = (pattern - pattern.min()) / (pattern.max() - pattern.min())
+# Helper to interpolate Alex Grey palette
+segments = len(PALETTE) - 1
 
-# Define a pastel palette inspired by Hilma af Klint (RGB 0-1)
-palette = np.array([
-    [255, 200, 221],  # soft rose
-    [211, 226, 255],  # pale sky
-    [255, 255, 204],  # light gold
-    [204, 246, 221],  # mint
-    [229, 203, 255],  # lavender
-]) / 255.0
+def palette_color(value, gradient):
+    pos = value * segments
+    idx = int(pos)
+    frac = pos - idx
+    r1, g1, b1 = PALETTE[idx]
+    r2, g2, b2 = PALETTE[min(idx + 1, segments)]
+    r = int((r1 + (r2 - r1) * frac) * gradient)
+    g = int((g1 + (g2 - g1) * frac) * gradient)
+    b = int((b1 + (b2 - b1) * frac) * gradient)
+    return r, g, b
 
-# Interpolate the palette across the normalized pattern
-xp = np.linspace(0, 1, len(palette))
-RGB = np.empty((HEIGHT, WIDTH, 3))
-for c in range(3):
-    RGB[..., c] = np.interp(pattern_norm, xp, palette[:, c])
+# Second pass: generate PNG scanlines
+scanlines = bytearray()
+for j in range(HEIGHT):
+    ty = -math.pi + j * Y_SCALE
+    scanlines.append(0)  # no filter for this row
+    for i in range(WIDTH):
+        tx = -math.pi + i * X_SCALE
+        r = math.hypot(tx, ty)
+        t = math.atan2(ty, tx)
+        pattern = (
+            math.sin(3 * r) +
+            math.cos(5 * t) +
+            math.sin(2 * (tx + ty)) +
+            math.cos(2 * (tx - ty))
+        )
+        norm = (pattern - min_val) / range_val
+        gradient = 1 - min(r / R_MAX, 1)
+        scanlines.extend(palette_color(norm, gradient))
 
-# Convert to 8-bit color and create image
-img = Image.fromarray((RGB * 255).astype(np.uint8))
+# Build PNG chunks
+png = bytearray(b"\x89PNG\r\n\x1a\n")
+# IHDR chunk
+ihdr = struct.pack(">IIBBBBB", WIDTH, HEIGHT, 8, 2, 0, 0, 0)
+png.extend(struct.pack(">I", len(ihdr)))
+png.extend(b"IHDR")
+png.extend(ihdr)
+png.extend(struct.pack(">I", zlib.crc32(b"IHDR" + ihdr) & 0xFFFFFFFF))
+# IDAT chunk
+compressed = zlib.compress(bytes(scanlines), level=9)
+png.extend(struct.pack(">I", len(compressed)))
+png.extend(b"IDAT")
+png.extend(compressed)
+png.extend(struct.pack(">I", zlib.crc32(b"IDAT" + compressed) & 0xFFFFFFFF))
+# IEND chunk
+png.extend(struct.pack(">I", 0))
+png.extend(b"IEND")
+png.extend(struct.pack(">I", zlib.crc32(b"IEND") & 0xFFFFFFFF))
 
-# Save the generated artwork
-img.save("Visionary_Dream.png")
-
+# Save final image
+with open("Visionary_Dream.png", "wb") as f:
+    f.write(png)


### PR DESCRIPTION
## Summary
- refactor visionary art generator to use only standard library
- embed PNG encoder and Alex Grey-inspired palette

## Testing
- `python visionary_dream.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba4c25c55c83288a6b755ac52fe6fc