### PR TITLE
refactor: pure python world builder

### DIFF
--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -1,45 +1,100 @@
-"""Generate a museum-quality visionary art piece inspired by Hilma af Klint."""
+"""Procedurally generate a colorful world map and save as Visionary_Dream.png."""
 
-# Import required libraries
-import numpy as np
-from PIL import Image
+import argparse
+import json
+import math
+import random
+import struct
+import zlib
 
-# Resolution of the output image (4K)
-WIDTH, HEIGHT = 3840, 2160
+# ------------------------------
+# Pure Python PNG writer
+# ------------------------------
+def write_png(filename, width, height, pixels):
+    """Write a 24-bit RGB PNG file."""
+    # Flatten pixel rows with filter byte 0
+    raw = b"".join(b"\x00" + bytes(r for rgb in row for r in rgb) for row in pixels)
+    compressor = zlib.compressobj()
+    compressed = compressor.compress(raw) + compressor.flush()
 
-# Generate a coordinate grid centered at the canvas origin
-x = np.linspace(-1, 1, WIDTH)
-y = np.linspace(-1, 1, HEIGHT)
-X, Y = np.meshgrid(x, y)
+    def chunk(tag, data):
+        crc = zlib.crc32(tag + data) & 0xFFFFFFFF
+        return struct.pack("!I", len(data)) + tag + data + struct.pack("!I", crc)
 
-# Compute polar coordinates for radial symmetry
-R = np.sqrt(X**2 + Y**2)
-T = np.arctan2(Y, X)
+    with open(filename, "wb") as f:
+        f.write(b"\x89PNG\r\n\x1a\n")
+        f.write(chunk(b"IHDR", struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)))
+        f.write(chunk(b"IDAT", compressed))
+        f.write(chunk(b"IEND", b""))
 
-# Layered trigonometric pattern for visionary geometry
-pattern = np.sin(8 * R**2 + 6 * T) + np.cos(4 * R - 3 * T)
+# ------------------------------
+# Interpolate between two colors
+# ------------------------------
+def lerp_color(c1, c2, t):
+    return tuple(int(a + (b - a) * t) for a, b in zip(c1, c2))
 
-# Normalize pattern to the range [0, 1]
-pattern_norm = (pattern - pattern.min()) / (pattern.max() - pattern.min())
+# ------------------------------
+# Generate a smooth height map
+# ------------------------------
+def generate_height_map(width, height, seed):
+    random.seed(seed)
+    grid = [[random.random() for _ in range(width)] for _ in range(height)]
+    # simple smoothing passes
+    for _ in range(3):
+        new = [[0.0] * width for _ in range(height)]
+        for y in range(height):
+            for x in range(width):
+                total = 0.0
+                count = 0
+                for dy in (-1, 0, 1):
+                    for dx in (-1, 0, 1):
+                        ny, nx = (y + dy) % height, (x + dx) % width
+                        total += grid[ny][nx]
+                        count += 1
+                new[y][x] = total / count
+        grid = new
+    return grid
 
-# Define a pastel palette inspired by Hilma af Klint (RGB 0-1)
-palette = np.array([
-    [255, 200, 221],  # soft rose
-    [211, 226, 255],  # pale sky
-    [255, 255, 204],  # light gold
-    [204, 246, 221],  # mint
-    [229, 203, 255],  # lavender
-]) / 255.0
+# ------------------------------
+# Map height values to Alex Grey inspired colors
+# ------------------------------
+PALETTE = [
+    (48, 0, 108),    # deep violet
+    (0, 170, 255),   # electric blue
+    (255, 93, 0),    # vibrant orange
+    (255, 255, 0),   # radiant yellow
+]
 
-# Interpolate the palette across the normalized pattern
-xp = np.linspace(0, 1, len(palette))
-RGB = np.empty((HEIGHT, WIDTH, 3))
-for c in range(3):
-    RGB[..., c] = np.interp(pattern_norm, xp, palette[:, c])
 
-# Convert to 8-bit color and create image
-img = Image.fromarray((RGB * 255).astype(np.uint8))
+def height_to_color(value):
+    if value < 0.33:
+        t = value / 0.33
+        c1, c2 = PALETTE[0], PALETTE[1]
+    elif value < 0.66:
+        t = (value - 0.33) / 0.33
+        c1, c2 = PALETTE[1], PALETTE[2]
+    else:
+        t = (value - 0.66) / 0.34
+        c1, c2 = PALETTE[2], PALETTE[3]
+    return lerp_color(c1, c2, t)
 
-# Save the generated artwork
-img.save("Visionary_Dream.png")
+# ------------------------------
+# Main execution
+# ------------------------------
+parser = argparse.ArgumentParser(description="Procedural visionary world builder")
+parser.add_argument("--width", type=int, default=256, help="map width")
+parser.add_argument("--height", type=int, default=256, help="map height")
+parser.add_argument("--seed", type=int, default=0, help="random seed")
+args = parser.parse_args()
 
+# Generate height map and corresponding RGB pixels
+heights = generate_height_map(args.width, args.height, args.seed)
+pixels = [[height_to_color(h) for h in row] for row in heights]
+
+# Save artwork
+write_png("Visionary_Dream.png", args.width, args.height, pixels)
+
+# Persist world data for game expansion
+world = {"width": args.width, "height": args.height, "map": heights}
+with open("visionary_world.json", "w") as f:
+    json.dump(world, f)


### PR DESCRIPTION
## Summary
- replace numpy-based art generator with a pure-Python procedural world builder
- emit Alex Grey-inspired maps to `Visionary_Dream.png` and save world data for expansion

## Testing
- `python visionary_dream.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba3b75a80c832882846d0acad025fa