### PR TITLE
fix package setup and schema guard

### DIFF
--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,26 +1,20 @@
-
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    let schema;
-    if(schemaUrl.startsWith("http")){
-      schema = await fetch(schemaUrl).then(r=>r.json());
-    }else{
-      const {readFile} = await import('node:fs/promises');
-      const p = schemaUrl.replace(/^\//, '');
-      schema = JSON.parse(await readFile(p, 'utf8'));
+// Minimal schema validator avoiding external dependencies.
+export async function validateInterface(payload, schemaUrl = "/assets/data/interface.schema.json") {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const p = schemaUrl.replace(/^\//, "");
+    const schema = JSON.parse(await readFile(p, "utf8"));
+    const errors = [];
+    const required = schema.required || [];
+    for (const key of required) {
+      if (!(key in payload)) errors.push({ message: `missing ${key}` });
     }
-    const AjvMod = await import("https://cdn.skypack.dev/ajv@8?min");
-
-// Validates incoming JSON against minimal interface schema; soft-fail to protect runtime.
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    const [schema, AjvMod] = await Promise.all([
-      fetch(schemaUrl).then(r=>r.json()),
-      import("https://cdn.skypack.dev/ajv@8?min")
-    ]);
-
-    const ajv = new AjvMod.default({allErrors:true, strict:false});
-    const valid = ajv.validate(schema, payload);
-    return {valid, errors: ajv.errors||[]};
-  }catch(e){ return {valid:false, errors:[{message:e.message}]}; }
+    if (typeof payload.version !== "string") errors.push({ message: "version must be string" });
+    if (!Array.isArray(payload.palettes)) errors.push({ message: "palettes must be array" });
+    if (!Array.isArray(payload.geometry_layers)) errors.push({ message: "geometry_layers must be array" });
+    if (!Array.isArray(payload.narrative_nodes)) errors.push({ message: "narrative_nodes must be array" });
+    return { valid: errors.length === 0, errors };
+  } catch (e) {
+    return { valid: false, errors: [{ message: e.message }] };
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "stone-grimoire",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stone-grimoire",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "stone-grimoire",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node tests/interface.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic package.json to enable automated Node checks
- replace broken Ajv import with small offline schema validator
- include npm lockfile for reproducible tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcadb6a834832886e55565faeab977