### PR TITLE
Add Node package setup and offline validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,4 +1,3 @@
-
 export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
   try{
     let schema;
@@ -9,18 +8,25 @@ export async function validateInterface(payload, schemaUrl="/assets/data/interfa
       const p = schemaUrl.replace(/^\//, '');
       schema = JSON.parse(await readFile(p, 'utf8'));
     }
-    const AjvMod = await import("https://cdn.skypack.dev/ajv@8?min");
-
-// Validates incoming JSON against minimal interface schema; soft-fail to protect runtime.
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    const [schema, AjvMod] = await Promise.all([
-      fetch(schemaUrl).then(r=>r.json()),
-      import("https://cdn.skypack.dev/ajv@8?min")
-    ]);
-
-    const ajv = new AjvMod.default({allErrors:true, strict:false});
-    const valid = ajv.validate(schema, payload);
-    return {valid, errors: ajv.errors||[]};
-  }catch(e){ return {valid:false, errors:[{message:e.message}]}; }
+    const required = schema.required || [];
+    const errors = [];
+    for(const key of required){
+      if(!(key in payload)){ errors.push({message:`missing ${key}`}); }
+    }
+    if('version' in payload && !/^\d+\.\d+\.\d+$/.test(payload.version)){
+      errors.push({message:"version format invalid"});
+    }
+    if('palettes' in payload && !Array.isArray(payload.palettes)){
+      errors.push({message:"palettes should be array"});
+    }
+    if('geometry_layers' in payload && !Array.isArray(payload.geometry_layers)){
+      errors.push({message:"geometry_layers should be array"});
+    }
+    if('narrative_nodes' in payload && !Array.isArray(payload.narrative_nodes)){
+      errors.push({message:"narrative_nodes should be array"});
+    }
+    return {valid:errors.length===0, errors};
+  }catch(e){
+    return {valid:false, errors:[{message:e.message}]};
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "stone-grimoire",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/interface.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal `package.json` with module type and test script
- ignore `node_modules` to keep repository clean
- rewrite `validateInterface` with offline schema loading and basic checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcad928fdc832886410b0b43ad3f06