### PR TITLE
feat: support repo adapters

### DIFF
--- a/docs/plugin_adapters.md
+++ b/docs/plugin_adapters.md
@@ -1,0 +1,29 @@
+# Plugin Adapters
+
+Adapters let external repositories extend the cathedral view without mutating core code. A repository declares an adapter in `assets/data/registry.json`:
+
+```json
+{
+  "name": "example-repo",
+  "path": "../example-repo",
+  "adapter": "scripts/adapter.mjs"
+}
+```
+
+## Module contract
+
+Each adapter is an ES module that exports an `init` function. It receives the shared view object and may augment it in place. The function may return a promise.
+
+```js
+// scripts/adapter.mjs
+export function init(view){
+  view.adapters = view.adapters || [];
+  view.adapters.push("example-repo");
+}
+```
+
+* `init(view)` — called after the base view is composed.
+* The `view` parameter is the global `__CATHEDRAL_VIEW__` object.
+* Adapters should be side‑effect free beyond mutating `view`.
+
+Failed imports or missing `init` are logged as warnings; they do not halt page load.

--- a/engines/cross-fetch.js
+++ b/engines/cross-fetch.js
@@ -1,11 +1,19 @@
 
-// Safe loader for foreign repo JSON by path hints in registry; forbids writing.
+// Safe loader for foreign repo resources by path hints in registry; forbids writing.
+// By default it fetches JSON, but it can also import ES modules when kind="module".
 
-export async function loadFromRepo(registry, repoName, relPath){
+export async function loadFromRepo(registry, repoName, relPath, kind="json"){
   const repo = registry.repos.find(r=>r.name===repoName);
   if(!repo) throw new Error("Unknown repo: "+repoName);
   const url = repo.path.replace(/\/$/,"") + "/" + relPath.replace(/^\//,"");
+
+  // Module loading avoids fetch to leverage native import handling.
+  if(kind === "module") return import(url);
+
   const res = await fetch(url, {cache:"no-store"});
   if(!res.ok) throw new Error("Missing: "+url);
+
+  // Text responses can be requested but default to JSON.
+  if(kind === "text") return await res.text();
   return await res.json();
 }

--- a/index.js
+++ b/index.js
@@ -19,12 +19,28 @@ if(controls.motion && controls.autoplay && controls.contrast){
 
 (async ()=>{
   const registry = await loadRegistry();
+
   const codexNodes = await loadFromRepo(registry, "cosmogenesis-learning-engine", "assets/data/codex144.json").catch(()=>[]);
   const spine33    = await loadFromRepo(registry, "circuitum99", "assets/data/spine33.json").catch(()=>[]);
   const rooms144   = await loadFromRepo(registry, "stone-grimoire", "assets/data/rooms144.json").catch(()=>[]);
+
   const shared = {version:"1.0.0", palettes:[], geometry_layers:[], narrative_nodes:[...codexNodes, ...spine33]};
   const guard = await validateInterface(shared);
   if(!guard.valid){ console.warn("Interface warnings:", guard.errors); }
+
   const view = composeView(shared, {});
   window.__CATHEDRAL_VIEW__ = {...view, rooms:rooms144};
+
+  // Adapter hooks: each repo may expose an adapter module with init(view).
+  for(const repo of registry.repos){
+    if(!repo.adapter) continue;
+    try{
+      const mod = await loadFromRepo(registry, repo.name, repo.adapter, "module");
+      if(mod && typeof mod.init === "function"){
+        mod.init(window.__CATHEDRAL_VIEW__);
+      }
+    }catch(err){
+      console.warn("Adapter load failed for", repo.name, err.message);
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
- allow `loadFromRepo` to import module scripts
- invoke repo adapter modules via a standardized `init(view)` hook
- document plugin adapter API

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in engines/interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdc4c24e483289d18b71766eabedc