### PR TITLE
Add Codex 144:99 interface node schema

### DIFF
--- a/assets/data/interface-node.schema.json
+++ b/assets/data/interface-node.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex144-99.org/schema/interface-node.json",
+  "title": "Codex 144:99 — Interface Node",
+  "description": "Cross-repo interface schema for Circuitum99 (soul:33), Cosmogenesis Learning Engine (mind:144:99), Stone Grimoire (body:temple), and Liber Arcanae (companion:78). Each exported node/layer declares numerology anchors and presentation geometry while remaining read-only and non-destructive.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "num",
+    "palette",
+    "geometry",
+    "node_type",
+    "narrative",
+    "locked"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable machine id unique within its source repo. Slug style.",
+      "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$",
+      "examples": ["shekinah.rose", "arcana.XVII.star", "room.jacobs_ladder", "daemon.fenrix"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable title of the node.",
+      "minLength": 1
+    },
+    "num": {
+      "description": "Numerology anchor used for cross-repo routing (e.g., 11, 22, 33, 72, 78, 99, 144, 243).",
+      "oneOf": [
+        { "type": "integer" },
+        { "type": "string", "pattern": "^[0-9]{1,3}$" }
+      ]
+    },
+    "palette": {
+      "type": "object",
+      "description": "Museum-grade swatch for this node.",
+      "additionalProperties": false,
+      "required": ["primary", "secondary", "accent"],
+      "properties": {
+        "primary": {
+          "type": "string",
+          "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+          "description": "Primary hex color."
+        },
+        "secondary": {
+          "type": "string",
+          "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+          "description": "Secondary hex color."
+        },
+        "accent": {
+          "type": "string",
+          "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+          "description": "Accent hex color."
+        }
+      }
+    },
+    "geometry": {
+      "type": "string",
+      "description": "Primary sacred geometry used when rendering.",
+      "enum": [
+        "vesica",
+        "monas",
+        "double_tree",
+        "golden_spiral",
+        "quartered_circle",
+        "compass",
+        "ladder",
+        "rose",
+        "cube",
+        "cone",
+        "grid",
+        "wheel"
+      ]
+    },
+    "node_type": {
+      "type": "string",
+      "description": "Semantic type of the node.",
+      "enum": [
+        "tarot_archetype",
+        "codex_node",
+        "realm_layer",
+        "avatar",
+        "daimon",
+        "ritual"
+      ]
+    },
+    "narrative": {
+      "type": "string",
+      "description": "One-line role or caption for plaques and banners.",
+      "minLength": 1,
+      "maxLength": 240
+    },
+    "locked": {
+      "type": "boolean",
+      "description": "If true, this node is immutable; renderers MUST NOT mutate or overwrite source lore."
+    },
+
+    "provenance": {
+      "type": "object",
+      "description": "Optional provenance block for museum-grade traceability.",
+      "additionalProperties": false,
+      "properties": {
+        "curator": { "type": "string", "description": "Curator or author credit." },
+        "sources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Citations or URLs to lawful editions / PD materials."
+        },
+        "license": { "type": "string", "description": "License short-name (e.g., CC-BY-4.0, PD, ARR)." },
+        "date": { "type": "string", "format": "date", "description": "ISO date of last curation." }
+      }
+    },
+
+    "constants": {
+      "type": "array",
+      "description": "Optional list of Codex constants the node binds to (e.g., 21 pillars, 33 spine, 72 Shem, 78 archetypes, 99 gates, 144 lattice, 243 completion).",
+      "items": {
+        "type": "integer",
+        "enum": [21, 33, 72, 78, 99, 144, 243]
+      },
+      "uniqueItems": true
+    },
+
+    "relations": {
+      "type": "array",
+      "description": "Optional cross-links to other nodes by id or numerology constant; read-only mapping for live bridges.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["angel", "daemon", "tarot", "room", "stylepack", "egregore", "sound", "guide"]
+          },
+          "target_id": { "type": "string", "description": "Foreign node id (if known)." },
+          "target_num": {
+            "description": "Foreign numerology anchor used for lookup when id is unknown.",
+            "oneOf": [
+              { "type": "integer" },
+              { "type": "string", "pattern": "^[0-9]{1,3}$" }
+            ]
+          },
+          "role": { "type": "string", "description": "How the relation functions (e.g., consecration, echo, overlay, patron, counterpart)." }
+        }
+      }
+    },
+
+    "render": {
+      "type": "object",
+      "description": "Optional presentation hints respected by renderers; never destructive.",
+      "additionalProperties": false,
+      "properties": {
+        "stylepack": { "type": "string", "description": "Preferred stylepack key (e.g., hilma_spiral, angelic_chorus)." },
+        "tone_hz": { "type": "number", "minimum": 20, "maximum": 20000, "description": "Preferred center frequency; ND-safe, no autoplay." },
+        "planetary": {
+          "type": "string",
+          "enum": ["sun", "moon", "mercury", "venus", "mars", "jupiter", "saturn"],
+          "description": "Planetary hour affinity."
+        },
+        "overlays": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["halos", "veils", "tracery", "fractal", "cymatic"] }
+        }
+      }
+    },
+
+    "source": {
+      "type": "object",
+      "description": "Read-only mirror information for bridge helpers.",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "enum": ["circuitum99", "cosmogenesis-learning-engine", "stone-grimoire", "liber-arcanae"],
+          "description": "Origin repository."
+        },
+        "path": { "type": "string", "description": "Origin path inside the repo (read-only mirror)." },
+        "sha": { "type": "string", "description": "Optional content hash/commit for integrity." }
+      }
+    }
+  },
+  "examples": [
+    {
+      "id": "room.egregore_sky",
+      "name": "Egregore Sky",
+      "num": 144,
+      "palette": { "primary": "#1f6feb", "secondary": "#f8f5ef", "accent": "#d4af37" },
+      "geometry": "wheel",
+      "node_type": "realm_layer",
+      "narrative": "Living constellation canopy linking 72 Shem and 78 archetypes across the 144 lattice.",
+      "locked": true,
+      "constants": [99, 144],
+      "render": { "stylepack": "angelic_chorus", "overlays": ["halos", "tracery"] },
+      "source": { "repo": "stone-grimoire", "path": "chapels/egregore-sky.html" }
+    },
+    {
+      "id": "arcana.XI.strength",
+      "name": "Strength",
+      "num": 78,
+      "palette": { "primary": "#8b5e34", "secondary": "#fff9f4", "accent": "#6d28d9" },
+      "geometry": "vesica",
+      "node_type": "tarot_archetype",
+      "narrative": "Compassion bridled to power; lion as daimon echo.",
+      "locked": true,
+      "relations": [
+        { "type": "angel", "target_num": 72, "role": "consecration" },
+        { "type": "room", "target_id": "room.lady_chapel", "role": "altar" }
+      ],
+      "source": { "repo": "liber-arcanae", "path": "cards/11-strength.json" }
+    },
+    {
+      "id": "story.spine.step_07",
+      "name": "Vertebra VII — The Lovers Gate",
+      "num": 33,
+      "palette": { "primary": "#6b59e6", "secondary": "#ffffff", "accent": "#d5e8ff" },
+      "geometry": "double_tree",
+      "node_type": "codex_node",
+      "narrative": "Playable companion rite on the tilted axis; twin currents reconcile.",
+      "locked": false,
+      "render": { "tone_hz": 528, "planetary": "venus" },
+      "source": { "repo": "circuitum99", "path": "book/spine/07.json" }
+    }
+  ]
+}

--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,50 +1,33 @@
 // Minimal schema validator avoiding external dependencies.
-export async function validateInterface(payload, schemaUrl = "/assets/data/interface.schema.json") {
+export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json") {
   try {
-    const { readFile } = await import("node:fs/promises");
-    const p = schemaUrl.replace(/^\//, "");
-    const schema = JSON.parse(await readFile(p, "utf8"));
-    const errors = [];
+    let schema;
+    if (schemaUrl.startsWith("http")) {
+      schema = await fetch(schemaUrl).then(r => r.json());
+    } else {
+      const { readFile } = await import("node:fs/promises");
+      const p = schemaUrl.replace(/^\//, "");
+      schema = JSON.parse(await readFile(p, "utf8"));
+    }
     const required = schema.required || [];
+    const errors = [];
     for (const key of required) {
       if (!(key in payload)) errors.push({ message: `missing ${key}` });
     }
-    if (typeof payload.version !== "string") errors.push({ message: "version must be string" });
-    if (!Array.isArray(payload.palettes)) errors.push({ message: "palettes must be array" });
-    if (!Array.isArray(payload.geometry_layers)) errors.push({ message: "geometry_layers must be array" });
-    if (!Array.isArray(payload.narrative_nodes)) errors.push({ message: "narrative_nodes must be array" });
+    if ("version" in payload && !/^\d+\.\d+\.\d+$/.test(payload.version)) {
+      errors.push({ message: "version format invalid" });
+    }
+    if ("palettes" in payload && !Array.isArray(payload.palettes)) {
+      errors.push({ message: "palettes should be array" });
+    }
+    if ("geometry_layers" in payload && !Array.isArray(payload.geometry_layers)) {
+      errors.push({ message: "geometry_layers should be array" });
+    }
+    if ("narrative_nodes" in payload && !Array.isArray(payload.narrative_nodes)) {
+      errors.push({ message: "narrative_nodes should be array" });
+    }
     return { valid: errors.length === 0, errors };
   } catch (e) {
     return { valid: false, errors: [{ message: e.message }] };
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    let schema;
-    if(schemaUrl.startsWith("http")){
-      schema = await fetch(schemaUrl).then(r=>r.json());
-    }else{
-      const {readFile} = await import('node:fs/promises');
-      const p = schemaUrl.replace(/^\//, '');
-      schema = JSON.parse(await readFile(p, 'utf8'));
-    }
-    const required = schema.required || [];
-    const errors = [];
-    for(const key of required){
-      if(!(key in payload)){ errors.push({message:`missing ${key}`}); }
-    }
-    if('version' in payload && !/^\d+\.\d+\.\d+$/.test(payload.version)){
-      errors.push({message:"version format invalid"});
-    }
-    if('palettes' in payload && !Array.isArray(payload.palettes)){
-      errors.push({message:"palettes should be array"});
-    }
-    if('geometry_layers' in payload && !Array.isArray(payload.geometry_layers)){
-      errors.push({message:"geometry_layers should be array"});
-    }
-    if('narrative_nodes' in payload && !Array.isArray(payload.narrative_nodes)){
-      errors.push({message:"narrative_nodes should be array"});
-    }
-    return {valid:errors.length===0, errors};
-  }catch(e){
-    return {valid:false, errors:[{message:e.message}]};
   }
 }


### PR DESCRIPTION
## Summary
- add Codex 144:99 interface node schema for cross-repo numerology nodes
- tidy interface validator to load schemas and report validation errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcdf4d13d083289eb953f53a916470