### PR TITLE
chore: add matrix-style ascii header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- Matrix-style helix header: ND-safe static ASCII art -->
+```
+01\    /10\    /01\    /10
+10 \  / 01 \  / 10 \  / 01
+01  \/  10  \/  01  \/  10
+10  /\  01  /\  10  /\  01
+01 /  \10 /  \01 /  \10
+10/    \01/    \10/    \01
+```
+
 ✦ LIBER ARCANAE: CODEX ABYSSIAE
 
 Abyssian Tarot of the Living Monad Hieroglyphica


### PR DESCRIPTION
## Summary
- add a matrix-inspired helix ASCII block at the top of the main README

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68bde283d7548328a33a422fe3fcc6a1