### PR TITLE
chore: clarify offline palette load in helix renderer

### DIFF
--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -51,6 +51,7 @@
       }
     };
 
+    // Offline-safe: attempts to load local palette; no external requests
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";


### PR DESCRIPTION
## Summary
- comment in helix renderer index: note offline local palette and fallback

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68bde90b16ec8328941ca707b8d7eb0a