### PR TITLE
docs: document multiclass templates

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -58,3 +58,39 @@ Accessibility / ND-Friendly
 	•	High-contrast skins
 	•	ARIA roles/labels
 	•	Cymatic blooms (for non-hearing), narrated glyphs (for non-seeing)
+
+⸻
+
+## Multiclass Templates (Agate)
+
+Stone Grimoire exports a small set of ES module templates so that other
+repositories can reuse cathedral features without copying code. Each
+template is ND-safe and side-effect free.
+
+### cross-fetch.js
+- `loadFromRepo(registry, repoName, relPath, kind="json")`
+  - Resolves a file from a sibling repo listed in `registry`.
+  - `kind` may be "json", "text", or "module".
+  - Returns parsed JSON, text, or a dynamic import.
+
+### interface-guard.js
+- `validateInterface(payload, schemaUrl="/assets/data/interface.schema.json")`
+  - Loads a JSON schema (local path or remote URL).
+  - Checks required keys, semantic version, and array fields.
+  - Returns `{ valid:boolean, errors:[] }`.
+
+### merge-view.js
+- `composeView({palettes=[], geometry_layers=[], narrative_nodes=[]}, overlays={})`
+  - Deep-freezes arrays to prevent mutation.
+  - Merges overlay arrays into a new view object.
+  - Returns an immutable snapshot.
+
+### registry-loader.js
+- `loadRegistry(url="/assets/data/registry.json")`
+  - Fetches and parses the repository registry.
+  - Throws if the file is missing.
+
+These templates form the external contract for composing multiclass
+views: load a registry, fetch cross-repo assets, validate interface
+payloads, then merge overlays into a frozen view. Other modules may call
+them but must respect their pure, read-only design.


### PR DESCRIPTION
## Summary
- document multiclass template modules and external API contracts in integration guide

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export' in engines/interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a5d2120832898ce654b24bbf218