### PR TITLE
docs: clarify offline fallback

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -11,7 +11,7 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If that file is missing, the renderer falls back to a safe default palette.
+Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -27,6 +27,7 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
+    // Offline-first: import local module; no network requests.
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
@@ -51,6 +52,7 @@
       }
     };
 
+    // Load palette file; fall back to calm defaults when missing.
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";


### PR DESCRIPTION
## Summary
- note offline-first import and palette fallback in helix renderer HTML
- document palette fallback notice in helix renderer README

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*


------
https://chatgpt.com/codex/tasks/task_e_68be1b82e0508328b3eaeeb7abf83fd2