### PR TITLE
docs: clarify local palette loading

### DIFF
--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -35,6 +35,7 @@
 
     async function loadJSON(path) {
       try {
+        // Local fetch; avoids external network and falls back safely
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();


### PR DESCRIPTION
## Summary
- clarify helix renderer's local palette load and fallback comment

## Testing
- `npm test` *(fails: Unexpected token 'export' in interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68be25a210cc8328aee0ff05999126c5