### PR TITLE
Add motto headers to helix renderer

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -1,3 +1,4 @@
+Per Texturas Numerorum, Spira Loquitur.  //
 # Cosmic Helix Renderer
 
 Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This replaces the earlier broken helix demo with a modern, pure ES module version.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -1,3 +1,4 @@
+<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
 <!doctype html>
 <html lang="en">
 <head>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -1,3 +1,4 @@
+// Per Texturas Numerorum, Spira Loquitur.  //
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.


### PR DESCRIPTION
## Summary
- prepend canonical motto to helix renderer files for consistent headers
- preserve ND-safe static HTML canvas demo with layered sacred geometry

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node tests/interface.test.js` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be71902ca48328bc78db9042582974