### PR TITLE
docs: clarify helix renderer palette fallback

### DIFF
--- a/cosmogenesis-learning-engine/README_RENDERER.md
+++ b/cosmogenesis-learning-engine/README_RENDERER.md
@@ -10,10 +10,10 @@ Static, offline-first canvas renderer for layered sacred geometry.
 
 ## Usage
 - Open `index.html` directly in a modern browser (no server required).
-- Adjust colors by editing `data/palette.json`. Missing palette falls back to safe defaults.
+- Adjust colors by editing `data/palette.json`. Missing palette triggers a small notice and the renderer uses a safe fallback palette.
 
 ## ND-safe Notes
 - No motion or autoplay; all geometry renders once on load.
-- High-contrast yet soft palette for sensory safety.
-- No external dependencies, workflows, or network calls.
+- High-contrast yet soft palette and gentle layer ordering for sensory safety.
+- No external dependencies, workflows, or network calls; everything stays offline.
 - Numerology constants (3,7,9,11,22,33,99,144) anchor proportions.


### PR DESCRIPTION
## Summary
- clarify palette fallback notice in Cosmic Helix Renderer readme
- reiterate ND-safe layer order and offline-only behaviour

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node tests/interface.test.js` *(fails: invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be8cf7e0148328bd03355e5b5ff8a8