### PR TITLE
Apply palette colors to helix renderer page

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -9,7 +9,7 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette.
+Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette. These values also set the page background and text color for consistent offline theming.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -52,6 +52,10 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
+    // Apply palette to page for consistent ND-safe colors
+    const root = document.documentElement;
+    root.style.setProperty("--bg", active.bg);
+    root.style.setProperty("--ink", active.ink);
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants used by geometry routines


### PR DESCRIPTION
## Summary
- Apply palette's background and text colors to the helix renderer page for consistent offline theming
- Document palette theming in README_RENDERER

## Testing
- `npm test` *(fails: Invalid package.json EJSONPARSE)*

------
https://chatgpt.com/codex/tasks/task_e_68c11ac6bac8832893bf38ab4ea1ba2e