### PR TITLE
chore: dedupe helix renderer docs

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -10,10 +10,7 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast.
-Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast.
-Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette. These values also set the page background and text color for consistent offline theming.
+Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -53,24 +53,8 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Apply palette to page for consistent ND-safe colors (why: maintain gentle contrast)
-    const root = document.documentElement;
-    // Apply palette to page for consistent ND-safe colors
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-
-    // Apply palette to page for consistent ND-safe colors
-
-    // Apply palette to page and update status once
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-    // Inline notice signals whether palette file was present (why: offline clarity)
-    // apply active palette to page chrome for readability
-
-    // Apply palette once to respect existing page structure (why: avoids duplicate assignments)
+    // Apply palette once for calm, readable contrast (why: ND-safe colors)
     const root = document.documentElement;
     root.style.setProperty("--bg", active.bg);
     root.style.setProperty("--ink", active.ink);

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node tests/interface.test.js",
-    "dedupe": "node scripts/deduplicate-repo.mjs"
-    "dedupe": "node scripts/dedupe.js"
-
+    "dedupe": "node scripts/deduplicate-repo.mjs",
+    "dedupe-file": "node scripts/dedupe.js"
   }
 }


### PR DESCRIPTION
## Summary
- remove duplicate palette loading and root assignments in helix renderer index
- collapse repeated palette section in renderer README
- fix package.json scripts to valid JSON

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68c4fc6e1ae48328a1739cc2e0e0d640