### PR TITLE
chore: clean helix renderer docs and palette handling

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -12,8 +12,6 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 ## Palette
 Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast.
 Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast.
-Colors are loaded from `data/palette.json`. If that file is missing, the renderer displays a small notice and falls back to a safe default palette. These values also set the page background and text color for consistent offline theming.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -53,28 +53,13 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Apply palette to page for consistent ND-safe colors (why: maintain gentle contrast)
-    const root = document.documentElement;
-    // Apply palette to page for consistent ND-safe colors
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-
-    // Apply palette to page for consistent ND-safe colors
-
-    // Apply palette to page and update status once
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
     // Inline notice signals whether palette file was present (why: offline clarity)
-    // apply active palette to page chrome for readability
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Apply palette once to respect existing page structure (why: avoids duplicate assignments)
+    // Apply palette once to page chrome for consistent ND-safe colors
     const root = document.documentElement;
     root.style.setProperty("--bg", active.bg);
     root.style.setProperty("--ink", active.ink);
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };


### PR DESCRIPTION
## Summary
- deduplicate palette setup in helix renderer index
- trim README to remove repeated palette notes

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fc995d908328ba1d10abcfed8c8e