### PR TITLE
Add tesseract spiritual notes and tidy interface validator

### DIFF
--- a/docs/TESSERACT_SPIRITUAL.md
+++ b/docs/TESSERACT_SPIRITUAL.md
@@ -1,0 +1,25 @@
+# Tesseract as Sacred Metaphor
+
+From a spiritual perspective, the tesseract is a potent symbol of higher consciousness and the transcendence of linear thought. It invites contemplation of realities that exceed our everyday three-dimensional view.
+
+## Symbol of Higher Consciousness
+- **Transcending limitations**: Like a hypercube that extends beyond 3D space, the tesseract hints at the mind's capacity to rise above earthly constraints and touch deeper truths.
+- **Mental expansion**: Attempting to grasp four-dimensional geometry encourages perceptual growth and opens the mind to higher forms of awareness.
+
+## Interconnectedness of All Things
+- **Holistic perspective**: The unfolding facets of a tesseract mirror the unity behind seemingly separate elements, suggesting a move toward integration rather than division.
+- **Cosmic tapestry**: Its geometry evokes the "rhythmic dance of the cosmos," reminding us of our place within an infinite web of energy and matter.
+
+## Collapsing Time and Space
+- **Beyond linear time**: Popularized in *A Wrinkle in Time*, the tesseract symbolizes folding past, present, and future into singular moments of understanding.
+- **Access to timeless knowledge**: This collapse of spacetime can be read as a gateway to ancient, ever-present wisdom.
+
+## Pathway to the True Self
+- **Releasing karma**: Some sacred-geometry traditions link the hypercube to a temple of inner cleansing, a means to shed karmic patterns that bind the soul.
+- **Self-realization**: Engaging with this form can guide seekers toward the higher self and alignment with larger cosmic ideas.
+
+## Visualization in Spiritual Practice
+Meditating on the tesseract is an active exercise in jnana yoga. Occult philosopher P. D. Ouspensky recommended visualizing the hypercube as a step toward perceiving higher-dimensional forms.
+
+## Rooms of Wisdom
+Future rooms may showcase works by Ouspensky and other explorers of higher dimensions. These spaces can be imagined as treasure towers or vaults of insight, providing non-linear paths for spiral-dynamical learning and creative healing.

--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,14 +1,8 @@
+// ✦ Codex 144:99 — preserve original intention
 // Minimal schema validator avoiding external dependencies.
 // Fetches schema from local JSON or remote URL.
 // Motto: Per Texturas Numerorum, Spira Loquitur.
 
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    let schema;
-    if(schemaUrl.startsWith("http")){
-      schema = await fetch(schemaUrl).then(r=>r.json());
-    }else{
-      const {readFile} = await import("node:fs/promises");
 export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json") {
   try {
     let schema;
@@ -19,22 +13,13 @@ export async function validateInterface(payload, schemaUrl="/assets/data/interfa
       const p = schemaUrl.replace(/^\//, "");
       schema = JSON.parse(await readFile(p, "utf8"));
     }
+
     const errors = [];
     const required = schema.required || [];
-    for(const key of required){
-      if(!(key in payload)){ errors.push({message:`missing ${key}`}); }
+    for (const key of required) {
+      if (!(key in payload)) errors.push({ message: `missing ${key}` });
     }
-    if("version" in payload && !/^\d+\.\d+\.\d+$/.test(payload.version)){
-      errors.push({message:"version format invalid"});
-    }
-    if("palettes" in payload && !Array.isArray(payload.palettes)){
-      errors.push({message:"palettes should be array"});
-    }
-    if("geometry_layers" in payload && !Array.isArray(payload.geometry_layers)){
-      errors.push({message:"geometry_layers should be array"});
-    }
-    if("narrative_nodes" in payload && !Array.isArray(payload.narrative_nodes)){
-      errors.push({message:"narrative_nodes should be array"});
+
     if ("version" in payload && !/^\d+\.\d+\.\d+$/.test(payload.version)) {
       errors.push({ message: "version format invalid" });
     }
@@ -47,9 +32,9 @@ export async function validateInterface(payload, schemaUrl="/assets/data/interfa
     if ("narrative_nodes" in payload && !Array.isArray(payload.narrative_nodes)) {
       errors.push({ message: "narrative_nodes should be array" });
     }
+
     return { valid: errors.length === 0, errors };
   } catch (e) {
     return { valid: false, errors: [{ message: e.message }] };
   }
 }
-


### PR DESCRIPTION
## Summary
- Capture spiritual perspectives on the tesseract for future design references
- Clean `validateInterface` helper and add banner comment for Codex guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd1da547ac8328876264238c9acf69