### PR TITLE
chore: clean helix renderer docs

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -11,7 +11,6 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 
 ## Palette
 Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -59,12 +59,6 @@
     root.style.setProperty("--bg", active.bg);
     root.style.setProperty("--ink", active.ink);
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Apply palette to page for gentle contrast (why: ND-safe readability)
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };


### PR DESCRIPTION
## Summary
- deduplicate palette setup in helix renderer index
- trim repeated palette notes in helix renderer README

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68c731b88ef48328aa6a2f1ead051b61