### PR TITLE
Add Aurora Gate Zero Point page and Node 1 placeholder

### DIFF
--- a/chapels/aurora-gate/index.html
+++ b/chapels/aurora-gate/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Aurora Gate — Zero Point (Fool · Node 00)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- ND-safe, strict but practical CSP -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self';">
+  <link rel="preload" href="../../assets/img/carrington-gate-1280.avif" as="image">
+  <style>
+    :root{--obsidian:#0F0B1E;--teal:#29C7CE;--gold:#F6C847;--violet:#7A3EB1}
+    *{box-sizing:border-box} html{color-scheme:dark light}
+    body{margin:0;background:var(--obsidian);color:#eee;font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+    .wrap{max-width:72rem;margin:auto;padding:2rem}
+    header{padding:1.25rem 2rem;border-bottom:1px solid #222}
+    h1,h2{margin:.25rem 0 .5rem} .sub{opacity:.85}
+    .lede{opacity:.9}
+    img,picture{display:block;max-width:100%;height:auto}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:1rem;margin-top:1rem}
+    .card{border:1px solid #222;background:#0b0a13;border-radius:.75rem;padding:1rem}
+    .tag{display:inline-block;font-size:.8rem;opacity:.85;margin:.25rem .25rem 0 0;border:1px solid #333;border-radius:.5rem;padding:.1rem .4rem}
+    .choices{display:flex;flex-wrap:wrap;gap:.75rem;margin:1rem 0}
+    .btn{cursor:pointer;border:1px solid #333;border-radius:.6rem;background:#111;color:#fff;padding:.6rem .9rem}
+    .btn:hover{background:#151515}
+    a{color:var(--teal);text-decoration:none;border-bottom:1px solid currentColor}
+    a:hover{opacity:.9}
+    .note{opacity:.8;font-size:.95rem}
+    @media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Zero Point — Aurora Gate</h1>
+    <p class="sub">Fool · Node 00 · double Tree threshold</p>
+  </header>
+
+  <main class="wrap" aria-live="polite">
+    <!-- Hero art (responsive, ND-safe) -->
+    <figure>
+      <picture>
+        <source type="image/avif"
+          srcset="../../assets/img/carrington-gate-1280.avif 1280w, ../../assets/img/carrington-gate-1920.avif 1920w"
+          sizes="(max-width:640px) 92vw, 1200px">
+        <source type="image/webp"
+          srcset="../../assets/img/carrington-gate-1280.webp 1280w, ../../assets/img/carrington-gate-1920.webp 1920w"
+          sizes="(max-width:640px) 92vw, 1200px">
+        <img src="../../assets/img/carrington-gate-1280.jpg" width="1200" height="675" decoding="async" loading="eager"
+             alt="Aurora seam before an obsidian mirror; quiet stars; threshold without strobe.">
+      </picture>
+      <figcaption class="note">Aurora Gate is ND-safe by covenant: no strobe, no autoplay.</figcaption>
+    </figure>
+
+    <!-- Liminal text -->
+    <p class="lede">The kitchen is a laboratory. A horse and a hyena keep watch. Step through the aurora seam—or attend the stone.</p>
+
+    <!-- Mode toggle -->
+    <div class="choices">
+      <button class="btn" data-mode="story">Story</button>
+      <button class="btn" data-mode="game">Game</button>
+      <button class="btn" data-mode="art">Art</button>
+      <button class="btn" data-mode="research">Research</button>
+    </div>
+
+    <!-- Operators (egregore voices) -->
+    <section>
+      <h2>Operators active at Zero</h2>
+      <div id="ops" class="grid" role="list"></div>
+    </section>
+
+    <!-- Crystal kit -->
+    <section>
+      <h2>Crystals in play</h2>
+      <div id="crystals" class="grid" role="list"></div>
+    </section>
+
+    <!-- Branches forward -->
+    <section>
+      <h2>Choose your movement</h2>
+      <div class="choices">
+        <a class="btn" href="../carrington-temple/index.html">Enter Carrington Temple →</a>
+        <a class="btn" href="../fool-node/index.html">See all Fool links →</a>
+        <a class="btn" id="to-node1" href="../malkuth-stone/index.html">Face the Stone of the Mother (Node 1) →</a>
+      </div>
+      <p class="note">Tip: append <code>?mode=game</code> (or story/art/research) to carry your lens forward.</p>
+    </section>
+  </main>
+
+  <script type="module">
+    // --- Config: canonical bundle path (Cosmogenesis is the source of truth) ---
+    const BUNDLE = "../../../../cosmogenesis-learning-engine/registry/arcana/Fool.bundle.json";
+
+    // --- Helpers ---
+    const $ = (q)=>document.querySelector(q);
+    const params = new URLSearchParams(location.search);
+    let MODE = params.get("mode") || "story";
+
+    const views = {
+      story(o){ return `<p class="note">${o.role || ""} · narrative lens</p>`; },
+      game(o){ return `<p class="note">${o.role || ""} · playable / witch-mod ready</p>`; },
+      art(o){ return `<p class="note">${o.role || ""} · atelier motifs</p>`; },
+      research(o){ return `<p class="note">${o.role || ""} · correspondences</p>`; }
+    };
+
+    // --- Renderers ---
+    function renderOperators(bundle){
+      const ops = $("#ops");
+      ops.innerHTML = (bundle.operators||[]).map(o=>`
+        <article class="card" role="listitem">
+          <h3>${o.label || o.id}</h3>
+          ${views[MODE](o)}
+          ${(bundle.symbols||[]).slice(0,4).map(t=>`<span class="tag">#${t}</span>`).join(" ")}
+        </article>`).join("");
+    }
+
+    function renderCrystals(bundle){
+      const root = $("#crystals");
+      const crystals = bundle.crystals || [];
+      root.innerHTML = crystals.map(c=>{
+        const info = (bundle.crystal_defs||[]).find(x=>x.id===c) || {};
+        const role = (info.role||"anchor");
+        const game = (info.gameplay||"");
+        const tags = (info.tags||[]).map(t=>`<span class="tag">#${t}</span>`).join(" ");
+        return `<article class="card" role="listitem">
+          <h3>${(info.label||c).replace(/_/g," ")}</h3>
+          <p class="note">${role}${game?` — ${game}`:""}</p>
+          ${tags}
+        </article>`;
+      }).join("");
+    }
+
+    function wireModeButtons(){
+      document.querySelectorAll('[data-mode]').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          MODE = btn.dataset.mode;
+          const url = new URL(location.href);
+          url.searchParams.set('mode', MODE);
+          history.replaceState({}, "", url);
+          // re-render with the new lens
+          init();
+        });
+      });
+      // carry mode to Node 1 link
+      const node1 = $("#to-node1");
+      if(node1){
+        const u = new URL(node1.href, location.href);
+        u.searchParams.set('mode', MODE);
+        node1.href = u.toString();
+      }
+    }
+
+    async function init(){
+      try{
+        const res = await fetch(BUNDLE, {cache:'no-store'});
+        const bundle = await res.json();
+        renderOperators(bundle);
+        renderCrystals(bundle);
+        wireModeButtons();
+      }catch(err){
+        console.error(err);
+        $("#ops").innerHTML = `<p class="note">Could not load bundle.</p>`;
+      }
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/chapels/malkuth-stone/index.html
+++ b/chapels/malkuth-stone/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Node 1 — Stone of the Mother (Malkuth)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self';">
+  <style>
+    :root{--obsidian:#0F0B1E;--teal:#29C7CE}
+    *{box-sizing:border-box} body{margin:0;background:var(--obsidian);color:#eee;font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+    .wrap{max-width:72rem;margin:auto;padding:2rem}
+    header{padding:1.25rem 2rem;border-bottom:1px solid #222}
+    .btn{display:inline-block;margin:.75rem 0;padding:.6rem .9rem;border:1px solid #333;border-radius:.6rem;background:#111;color:#fff;text-decoration:none}
+    .btn:hover{background:#151515}
+  </style>
+</head>
+<body>
+  <header><h1>Node 1 — Stone of the Mother</h1></header>
+  <main class="wrap">
+    <p>Place your hand on the stone (Vehuiah) — or turn toward the forest (shadow trial). Mode respected via <code>?mode=…</code>.</p>
+    <a class="btn" href="../aurora-gate/index.html">← Back to Zero</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add ND-safe Aurora Gate entry page with CSP, hero art, mode toggle, operators/crystals rendering, and branch links including Node 1.
- Provide minimal Node 1 placeholder page linked from Zero.

## Testing
- `npm test` *(fails: SyntaxError in engines/interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c75e1af41c8328a21876bf97255350