### PR TITLE
chore: align helix renderer script

### DIFF
--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -53,11 +53,6 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
-
-    // Apply palette once for calm, readable contrast (why: ND-safe colors)
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants used by geometry routines


### PR DESCRIPTION
## Summary
- streamline helix renderer index by removing unused palette CSS updates
- keep numerology-driven static layers for ND-safe geometry

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68c7752845fc83289ad2c55a35d69ca6