### PR TITLE
chore: sync helix palette with page

### DIFF
--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -53,6 +53,9 @@
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
+    const rootStyle = document.documentElement.style; // sync page colors with palette
+    rootStyle.setProperty("--bg", active.bg);
+    rootStyle.setProperty("--ink", active.ink);
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants used by geometry routines


### PR DESCRIPTION
## Summary
- ensure helix renderer applies palette colors to page styles for consistent contrast

## Testing
- `npm test` *(fails: Unexpected token 'export' in interface-guard.js)*
- `node --experimental-vm-modules tests/interface.test.js` *(fails: Unexpected token 'export' in interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c79a29f0f483288d659776684d5532