### PR TITLE
docs: clarify offline palette notice

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -30,3 +30,5 @@ The geometry routines honor key counts:
 
 ## Usage
 Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features.
+
+No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.


### PR DESCRIPTION
## Summary
- document that the helix renderer performs no network requests and reports missing palettes for offline use

## Testing
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*


------
https://chatgpt.com/codex/tasks/task_e_68c79ccc70608328b32fe8e56256e623