### PR TITLE
Refine offline helix renderer layering

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -3,6 +3,8 @@ Per Texturas Numerorum, Spira Loquitur.  //
 
 Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This replaces the earlier broken helix demo with a modern, pure ES module version.
 
+The HTML file works directly from disk: if the palette JSON cannot be read because of local browser restrictions, the module applies a calm fallback palette and the header status line explains why. No network calls leave the machine.
+
 ## Layers
 1. **Vesica field** – intersecting circles establishing the sacred lens.
 2. **Tree-of-Life scaffold** – 10 sephirot and 22 paths drawn with calm symmetry.
@@ -10,7 +12,9 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
+Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
+
+Default palette hues follow the trauma-informed guidance from the master plan: calm blues, restorative greens, mystical purples, and warm neutrals. All hues appear as high-contrast yet gentle strokes layered over the dark canvas.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.

--- a/helix-renderer/data/palette.json
+++ b/helix-renderer/data/palette.json
@@ -1,5 +1,6 @@
 {
   "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+  "ink": "#e5e5ea",
+  "muted": "#7f86a6",
+  "layers": ["#4a90e2", "#7bb3f0", "#7ed321", "#b8e986", "#9013fe", "#af52de"]
 }

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -8,19 +8,49 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+    :root {
+      --bg:#0b0b12;
+      --ink:#e5e5ea;
+      --muted:#7f86a6;
+      --frame:#1d1d2a;
+    }
+    html,body {
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--ink);
+      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+    }
+    header {
+      padding:12px 16px;
+      border-bottom:1px solid var(--frame);
+    }
+    .status {
+      color:var(--muted);
+      font-size:12px;
+    }
+    #stage {
+      display:block;
+      margin:16px auto;
+      box-shadow:0 0 0 1px var(--frame);
+      background:transparent;
+    }
+    .note {
+      max-width:900px;
+      margin:0 auto 16px;
+      color:var(--muted);
+    }
+    code {
+      background:#11111a;
+      padding:2px 4px;
+      border-radius:3px;
+    }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -33,33 +63,59 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadJSON(path) {
+    async function loadPalette(path) {
+      const isFile = window.location.protocol === "file:";
       try {
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
+        const data = await res.json();
+        return { data, message: "Palette loaded from data file." };
       } catch (err) {
-        return null;
+        const reason = isFile ? "Browser blocked file fetch;" : "Palette file missing;";
+        return { data: null, message: reason + " using safe fallback palette." };
       }
     }
 
+    function applyPalette(palette) {
+      const root = document.documentElement;
+      root.style.setProperty("--bg", palette.bg);
+      root.style.setProperty("--ink", palette.ink);
+      root.style.setProperty("--muted", palette.muted || palette.ink);
+      document.body.style.background = palette.bg;
+      document.body.style.color = palette.ink;
+    }
+
     const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      bg:"#0b0b12",
+      ink:"#e5e5ea",
+      muted:"#7f86a6",
+      layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const paletteResult = await loadPalette("./data/palette.json");
+    const activePalette = paletteResult.data || defaults;
+    applyPalette(activePalette);
+    elStatus.textContent = paletteResult.message;
 
     // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    const NUM = {
+      THREE:3,
+      SEVEN:7,
+      NINE:9,
+      ELEVEN:11,
+      TWENTYTWO:22,
+      THIRTYTHREE:33,
+      NINETYNINE:99,
+      ONEFORTYFOUR:144
+    };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, {
+      width:canvas.width,
+      height:canvas.height,
+      palette:activePalette,
+      NUM
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the offline index shell so palette data applies to the full page and communicates fallback states
- deepen the helix renderer layering with reusable color selection, softened vesica grids, bounded spirals, and translucent lattice work
- align the palette data and documentation with the trauma-informed color guidance and offline-first behavior

## Testing
- node --check helix-renderer/js/helix-renderer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68c8adc3de7483289085756a0a80aa0b