### PR TITLE
Refine helix renderer for offline ND-safe viewing

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -10,8 +10,7 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 4. **Double-helix lattice** - two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
+Colors are loaded from `data/palette.json`. If the file is missing—or a browser blocks `file://` fetches—the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
 
 ## ND-Safe Choices
 - No animation, motion, or autoplay.
@@ -30,7 +29,6 @@ The geometry routines honor key counts:
 - 144 - helix lattice struts
 
 ## Usage
-Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features.
-
-No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.
 Open `index.html` directly in any modern browser. The canvas is 1440x900 and uses only built-in browser features.
+
+No network requests are made; a small status message notes if the palette file is missing so offline use remains clear. To tweak tones, edit `data/palette.json` and refresh.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -33,11 +33,32 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    function getMutedColor(palette) {
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    function getMutedColor(palette, fallbackTone) {
       // ND-safe: keep interface text gentle even if palette omits a muted tone.
-      const fallback = "#a6a6c1";
-      const layerTone = palette.layers && palette.layers[5];
-      return layerTone || fallback;
+      if (!palette.layers || typeof palette.layers[5] !== "string") return fallbackTone;
+      return palette.layers[5];
+    }
+
+    function sanitizePalette(source, fallback) {
+      // Trauma-informed: never crash if JSON is partial; fill gaps with calm defaults.
+      if (!source || typeof source !== "object") return fallback;
+      const layers = fallback.layers.map((tone, index) => {
+        const candidate = source.layers && typeof source.layers[index] === "string" ? source.layers[index] : tone;
+        return candidate;
+      });
+      return {
+        bg: typeof source.bg === "string" ? source.bg : fallback.bg,
+        ink: typeof source.ink === "string" ? source.ink : fallback.ink,
+        layers
+      };
     }
 
     async function loadJSON(path) {
@@ -51,39 +72,28 @@
       }
     }
 
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
+    const paletteData = await loadJSON("./data/palette.json");
+    const active = sanitizePalette(paletteData, defaults.palette);
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
+    function applyPagePalette(palette) {
+      const rootStyle = document.documentElement.style;
+      rootStyle.setProperty("--bg", palette.bg);
+      rootStyle.setProperty("--ink", palette.ink);
+      rootStyle.setProperty("--muted", getMutedColor(palette, defaults.palette.layers[5]));
+    }
 
-    // Apply palette once for calm, readable contrast (why: ND-safe colors)
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-    const muted = getMutedColor(active);
-    const rootStyle = document.documentElement.style;
-    // ND-safe: apply palette to the entire page for consistent contrast and calm focus.
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    rootStyle.setProperty("--muted", muted);
-    const rootStyle = document.documentElement.style; // sync page colors with palette
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    applyPagePalette(active);
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
+    const statusBase = paletteData ? "Palette loaded; rendering static geometry." : "Palette missing; using safe fallback palette.";
+
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable; geometry skipped.";
+      elStatus.textContent = statusBase + " Canvas context unavailable; geometry skipped.";
     } else {
+      elStatus.textContent = statusBase;
       renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
     }
   </script>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -13,20 +13,39 @@
 // Small, pure, parameterized functions only; no animation, no external deps.
 // ND-safe: all drawings are static with high-contrast, calm palette.
 
+const FALLBACK_LAYERS = ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"];
+
+function selectLayerTone(layers, index) {
+  if (!Array.isArray(layers)) return FALLBACK_LAYERS[index];
+  const tone = layers[index];
+  return typeof tone === "string" ? tone : FALLBACK_LAYERS[index];
+}
+
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
-  ctx.fillStyle = palette.bg;
+  const safeBg = typeof palette.bg === "string" ? palette.bg : "#0b0b12";
+  ctx.save();
+  ctx.fillStyle = safeBg;
   ctx.fillRect(0, 0, width, height);
+  ctx.restore();
 
   // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix crown.
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+  const vesicaTone = selectLayerTone(palette.layers, 0);
+  const treeNodeTone = selectLayerTone(palette.layers, 1);
+  const treePathTone = selectLayerTone(palette.layers, 2);
+  const fibonacciTone = selectLayerTone(palette.layers, 3);
+  const helixStrandTone = selectLayerTone(palette.layers, 4);
+  const latticeTone = selectLayerTone(palette.layers, 5);
+
+  drawVesica(ctx, width, height, vesicaTone, NUM);
+  drawTree(ctx, width, height, treeNodeTone, treePathTone, NUM);
+  drawFibonacci(ctx, width, height, fibonacciTone, NUM);
+  drawHelix(ctx, width, height, helixStrandTone, latticeTone, NUM);
 }
 
 // L1 Vesica field: soft intersecting circles, gentle grid
 function drawVesica(ctx, w, h, color, NUM) {
+  ctx.save();
   const r = Math.min(w, h) / NUM.THREE; // radius tied to numerology
   const cx = w / 2;
   const cy = h / 2;
@@ -48,10 +67,12 @@ function drawVesica(ctx, w, h, color, NUM) {
     ctx.lineTo(x, cy + r);
   }
   ctx.stroke();
+  ctx.restore();
 }
 
 // L2 Tree-of-Life: 10 nodes + 22 paths (NUM.TWENTYTWO)
 function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
+  ctx.save();
   const stepY = h / NUM.ELEVEN; // vertical rhythm
   const xCenter = w / 2;
   const xOffset = w / NUM.THREE / 2; // three pillars
@@ -93,10 +114,12 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
     ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
     ctx.fill();
   }
+  ctx.restore();
 }
 
 // L3 Fibonacci curve: static polyline log spiral
 function drawFibonacci(ctx, w, h, color, NUM) {
+  ctx.save();
   const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
   const centerX = w / 2;
   const centerY = h / 2;
@@ -114,10 +137,12 @@ function drawFibonacci(ctx, w, h, color, NUM) {
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
+  ctx.restore();
 }
 
 // L4 Double-helix lattice: two phase-shifted sine waves with 144 struts
 function drawHelix(ctx, w, h, strandColor, latticeColor, NUM) {
+  ctx.save();
   const centerY = h / 2;
   const amp = h / NUM.THREE; // amplitude linked to threefold nature
   const steps = NUM.ONEFORTYFOUR; // lattice count
@@ -163,4 +188,5 @@ function drawHelix(ctx, w, h, strandColor, latticeColor, NUM) {
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
+  ctx.restore();
 }


### PR DESCRIPTION
## Summary
- harden the helix renderer boot script with palette sanitization, ND-safe fallbacks, and status messaging
- make the drawing module resilient to missing palette entries while preserving layered ordering and calm rendering
- clarify offline usage guidance for the renderer, including palette fallback behavior

## Testing
- Not run (static HTML/JS update)


------
https://chatgpt.com/codex/tasks/task_e_68c8da4fc86c8328b391617b2e0ab6fa