### PR TITLE
Refine helix renderer layout and ND-safe palette handling

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -1,4 +1,4 @@
-Per Texturas Numerorum, Spira Loquitur.  //
+Per Texturas Numerorum, Spira Loquitur. //
 # Cosmic Helix Renderer
 
 Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This replaces the earlier broken helix demo with a modern, pure ES module version.
@@ -6,14 +6,12 @@ Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html`
 The HTML file works directly from disk: if the palette JSON cannot be read because of local browser restrictions, the module applies a calm fallback palette and the header status line explains why. No network calls leave the machine.
 
 ## Layers
-1. **Vesica field** - intersecting circles establishing the sacred lens.
-2. **Tree-of-Life scaffold** - 10 sephirot and 22 paths drawn with calm symmetry.
-3. **Fibonacci curve** - static log spiral approximated with 99 points.
-4. **Double-helix lattice** - two phase-shifted sine strands with 144 vertical struts.
+1. **Vesica field** – intersecting circles establishing the sacred lens.
+2. **Tree-of-Life scaffold** – 10 sephirot and 22 paths drawn with calm symmetry.
+3. **Fibonacci curve** – static log spiral approximated with 99 points.
+4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
 
 ## Palette
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
 Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
 
 Default palette hues follow the trauma-informed guidance from the master plan: calm blues, restorative greens, mystical purples, and warm neutrals. All hues appear as high-contrast yet gentle strokes layered over the dark canvas.
@@ -21,21 +19,18 @@ Default palette hues follow the trauma-informed guidance from the master plan: c
 ## ND-Safe Choices
 - No animation, motion, or autoplay.
 - High-contrast yet soft color palette.
-- Simple ES module with no network requests.
+- Simple ES module with no external dependencies.
 
 ## Numerology
 The geometry routines honor key counts:
-- 3 - primary vesica radius and helix amplitude
-- 7 - vesica grid lines
-- 9 - spiral growth factor
-- 11 - vertical rhythm for the Tree of Life
-- 22 - sephirot paths
-- 33 - scaling reference for the spiral
-- 99 - points along the Fibonacci curve
-- 144 - helix lattice struts
+- 3 – primary vesica radius and helix amplitude.
+- 7 – vesica grid lines.
+- 9 – spiral growth factor.
+- 11 – vertical rhythm for the Tree of Life and spiral sweep.
+- 22 – sephirot paths.
+- 33 – scaling reference for the spiral.
+- 99 – points along the Fibonacci curve.
+- 144 – helix lattice struts.
 
 ## Usage
-Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features.
-
-No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.
-Open `index.html` directly in any modern browser. The canvas is 1440x900 and uses only built-in browser features.
+Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features. No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -1,4 +1,4 @@
-<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
+<!-- Per Texturas Numerorum, Spira Loquitur. //-->
 <!doctype html>
 <html lang="en">
 <head>
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
+    /* ND-safe: calm contrast, no motion, generous spacing. */
     :root {
       --bg:#0b0b12;
       --ink:#e5e5ea;
@@ -49,10 +49,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
     <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
+    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -61,78 +59,19 @@
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    function getMutedColor(palette) {
-      // ND-safe: keep interface text gentle even if palette omits a muted tone.
-      const fallback = "#a6a6c1";
-      const layerTone = palette.layers && palette.layers[5];
-      return layerTone || fallback;
-    }
-
-    async function loadJSON(path) {
-      // Offline-friendly: swallow file errors and fall back to defaults without alerts.
-    async function loadPalette(path) {
-      const isFile = window.location.protocol === "file:";
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        const data = await res.json();
-        return { data, message: "Palette loaded from data file." };
-      } catch (err) {
-        const reason = isFile ? "Browser blocked file fetch;" : "Palette file missing;";
-        return { data: null, message: reason + " using safe fallback palette." };
-      }
-    }
-
-    function applyPalette(palette) {
-      const root = document.documentElement;
-      root.style.setProperty("--bg", palette.bg);
-      root.style.setProperty("--ink", palette.ink);
-      root.style.setProperty("--muted", palette.muted || palette.ink);
-      document.body.style.background = palette.bg;
-      document.body.style.color = palette.ink;
-    }
-
     const defaults = {
-      bg:"#0b0b12",
-      ink:"#e5e5ea",
-      muted:"#7f86a6",
-      layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e5e5ea",
+        muted:"#7f86a6",
+        layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
+      }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-
-    // Apply palette once for calm, readable contrast (why: ND-safe colors)
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-    const muted = getMutedColor(active);
-    const rootStyle = document.documentElement.style;
-    // ND-safe: apply palette to the entire page for consistent contrast and calm focus.
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    rootStyle.setProperty("--muted", muted);
-    const rootStyle = document.documentElement.style; // sync page colors with palette
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-    const paletteResult = await loadPalette("./data/palette.json");
-    const activePalette = paletteResult.data || defaults;
-    applyPalette(activePalette);
-    elStatus.textContent = paletteResult.message;
-    const statusMessage = palette ? "Palette loaded." : "Palette not available; using safe fallback.";
-    elStatus.textContent = statusMessage;
-
-    // Update CSS variables so the surrounding page honors the active palette.
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-
-    // Numerology constants used by geometry routines
     const NUM = {
       THREE:3,
       SEVEN:7,
@@ -144,18 +83,65 @@
       ONEFORTYFOUR:144
     };
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable; geometry skipped.";
-    } else {
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    init();
+
+    async function init() {
+      const result = await loadPalette("./data/palette.json", defaults.palette);
+      applyPalette(result.palette);
+      statusEl.textContent = result.message;
+
+      if (!ctx) {
+        statusEl.textContent = "Canvas context unavailable; geometry skipped.";
+        return;
+      }
+
+      // ND-safe rationale: render once, no motion, gentle layering order.
+      renderHelix(ctx, {
+        width:canvas.width,
+        height:canvas.height,
+        palette:result.palette,
+        NUM
+      });
     }
-    renderHelix(ctx, {
-      width:canvas.width,
-      height:canvas.height,
-      palette:activePalette,
-      NUM
-    });
+
+    async function loadPalette(path, fallback) {
+      const offline = window.location.protocol === "file:";
+      try {
+        const res = await fetch(path, { cache:"no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        const raw = await res.json();
+        return {
+          palette: normalizePalette(raw, fallback),
+          message:"Palette loaded from data file."
+        };
+      } catch (err) {
+        const reason = offline ? "Browser blocked local palette fetch; " : "Palette file missing; ";
+        return {
+          palette:fallback,
+          message:reason + "using safe fallback palette."
+        };
+      }
+    }
+
+    function normalizePalette(raw, fallback) {
+      if (!raw) return fallback;
+      const safeLayers = Array.isArray(raw.layers) && raw.layers.length ? raw.layers : fallback.layers;
+      return {
+        bg: raw.bg || fallback.bg,
+        ink: raw.ink || fallback.ink,
+        muted: raw.muted || raw.ink || fallback.muted,
+        layers: safeLayers
+      };
+    }
+
+    function applyPalette(palette) {
+      const root = document.documentElement;
+      root.style.setProperty("--bg", palette.bg);
+      root.style.setProperty("--ink", palette.ink);
+      root.style.setProperty("--muted", palette.muted);
+      document.body.style.background = palette.bg;
+      document.body.style.color = palette.ink;
+    }
   </script>
 </body>
 </html>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -1,54 +1,54 @@
-// Per Texturas Numerorum, Spira Loquitur.  //
+// Per Texturas Numerorum, Spira Loquitur. //
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers:
+  Layers rendered in order:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
-    3) Fibonacci curve (log spiral polyline; static)
-    4) Double-helix lattice (two phase-shifted sine strands with 144 vertical struts)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
+    4) Double-helix lattice (two phase-shifted strands with 144 struts)
 */
 
-// Small, pure, parameterized functions only; no animation, no external deps.
-// ND-safe: all drawings are static with high-contrast, calm palette.
+// Small, pure, parameterized functions only; no animation, no external dependencies.
+// ND-safe: drawings are static with high-contrast yet gentle palette choices.
 
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
-  const colors = palette.layers || [];
+  const layers = Array.isArray(palette.layers) ? palette.layers : [];
+  const fallback = palette.ink || "#ffffff";
 
   ctx.save();
-  ctx.fillStyle = palette.bg;
+  ctx.fillStyle = palette.bg || "#000000";
   ctx.fillRect(0, 0, width, height);
   ctx.restore();
 
+  // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix lattice crown.
   drawVesica(ctx, width, height, {
-    rim: pickColor(colors, 0, palette.ink),
-    grid: pickColor(colors, 1, palette.ink)
+    rim: pickColor(layers, 0, fallback),
+    grid: pickColor(layers, 1, fallback)
   }, NUM);
+
   drawTree(ctx, width, height, {
-    path: pickColor(colors, 2, palette.ink),
-    node: pickColor(colors, 3, palette.ink)
+    path: pickColor(layers, 2, fallback),
+    node: pickColor(layers, 3, fallback)
   }, NUM);
-  drawFibonacci(ctx, width, height, pickColor(colors, 4, palette.ink), NUM);
+
+  drawFibonacci(ctx, width, height, pickColor(layers, 4, fallback), NUM);
+
   drawHelix(ctx, width, height, {
-    strand: pickColor(colors, 5, palette.ink),
-    lattice: pickColor(colors, 0, palette.ink)
+    strand: pickColor(layers, 5, fallback),
+    lattice: pickColor(layers, 0, fallback)
   }, NUM);
 }
 
-  // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix crown.
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
 function pickColor(list, index, fallback) {
   return list && list[index] ? list[index] : fallback;
 }
 
-// L1 Vesica field: soft intersecting circles, gentle grid
+// L1 Vesica field: soft intersecting circles + numerological grid.
 function drawVesica(ctx, w, h, colors, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // radius tied to numerology
+  const radius = Math.min(w, h) / NUM.THREE;
   const cx = w / 2;
   const cy = h / 2;
 
@@ -56,181 +56,165 @@ function drawVesica(ctx, w, h, colors, NUM) {
   ctx.strokeStyle = colors.rim;
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
-  ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
+  ctx.arc(cx - radius / 2, cy, radius, 0, Math.PI * 2);
+  ctx.arc(cx + radius / 2, cy, radius, 0, Math.PI * 2);
   ctx.stroke();
 
-  // subtle vesica grid using SEVEN vertical lines + ELEVEN horizontal guides
-  ctx.lineWidth = 1;
+  // Subtle vesica grid using 7 vertical and 11 horizontal guides.
   ctx.strokeStyle = colors.grid;
-  ctx.globalAlpha = 0.6; // ND-safe translucency to keep the grid gentle
-  const step = r / NUM.SEVEN;
+  ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.6; // ND-safe translucency keeps the grid gentle.
+
+  const verticalStep = radius / NUM.SEVEN;
   ctx.beginPath();
   for (let i = -NUM.SEVEN; i <= NUM.SEVEN; i++) {
-    const x = cx + i * step;
-    ctx.moveTo(x, cy - r);
-    ctx.lineTo(x, cy + r);
+    const x = cx + i * verticalStep;
+    ctx.moveTo(x, cy - radius);
+    ctx.lineTo(x, cy + radius);
   }
   ctx.stroke();
 
-  const horizonStep = r / NUM.ELEVEN;
+  const horizontalStep = radius / NUM.ELEVEN;
   ctx.beginPath();
-  for (let j = -NUM.ELEVEN; j <= NUM.ELEVEN; j += NUM.SEVEN) {
-    const y = cy + j * horizonStep;
-    ctx.moveTo(cx - r, y);
-    ctx.lineTo(cx + r, y);
+  for (let j = -NUM.ELEVEN; j <= NUM.ELEVEN; j++) {
+    const y = cy + j * horizontalStep;
+    ctx.moveTo(cx - radius, y);
+    ctx.lineTo(cx + radius, y);
   }
-  ctx.moveTo(cx - r, cy);
-  ctx.lineTo(cx + r, cy);
   ctx.stroke();
+
   ctx.restore();
 }
 
-// L2 Tree-of-Life: 10 nodes + 22 paths (NUM.TWENTYTWO)
+// L2 Tree-of-Life: 10 nodes + 22 connective paths.
 function drawTree(ctx, w, h, colors, NUM) {
-  const stepY = h / NUM.ELEVEN; // vertical rhythm
-  const xCenter = w / 2;
-  const xOffset = w / NUM.THREE / 2; // three pillars
+  const verticalStep = h / NUM.ELEVEN;
+  const centerX = w / 2;
+  const pillarOffset = (w / NUM.THREE) / 2;
 
-  const nodes = buildTreeNodes(xCenter, xOffset, stepY);
+  const nodes = buildTreeNodes(centerX, pillarOffset, verticalStep);
   const paths = buildTreePaths();
 
   ctx.save();
   ctx.strokeStyle = colors.path;
   ctx.lineWidth = 1;
   ctx.lineCap = "round";
-  for (const [a, b] of paths) {
-    const p1 = nodes[a];
-    const p2 = nodes[b];
+  for (const [from, to] of paths) {
+    const start = nodes[from];
+    const end = nodes[to];
     ctx.beginPath();
-    ctx.moveTo(p1.x, p1.y);
-    ctx.lineTo(p2.x, p2.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
 
-  const r = Math.min(w, h) / NUM.THREE / NUM.ELEVEN; // small node radius
+  const nodeRadius = Math.min(w, h) / (NUM.THREE * NUM.ELEVEN);
   ctx.fillStyle = colors.node;
-  for (const n of nodes) {
+  for (const node of nodes) {
     ctx.beginPath();
-    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
   }
   ctx.restore();
 }
 
-function buildTreeNodes(xCenter, xOffset, stepY) {
+function buildTreeNodes(centerX, offsetX, stepY) {
   return [
-    { x: xCenter, y: stepY },
-    { x: xCenter + xOffset, y: stepY * 2 },
-    { x: xCenter - xOffset, y: stepY * 2 },
-    { x: xCenter + xOffset, y: stepY * 4 },
-    { x: xCenter - xOffset, y: stepY * 4 },
-    { x: xCenter, y: stepY * 5 },
-    { x: xCenter + xOffset, y: stepY * 7 },
-    { x: xCenter - xOffset, y: stepY * 7 },
-    { x: xCenter, y: stepY * 8 },
-    { x: xCenter, y: stepY * 10 }
+    { x:centerX, y:stepY },
+    { x:centerX + offsetX, y:stepY * 2 },
+    { x:centerX - offsetX, y:stepY * 2 },
+    { x:centerX + offsetX, y:stepY * 4 },
+    { x:centerX - offsetX, y:stepY * 4 },
+    { x:centerX, y:stepY * 5 },
+    { x:centerX + offsetX, y:stepY * 7 },
+    { x:centerX - offsetX, y:stepY * 7 },
+    { x:centerX, y:stepY * 8 },
+    { x:centerX, y:stepY * 10 }
   ];
 }
 
 function buildTreePaths() {
   return [
-    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
-    [5, 6], [5, 7], [6, 7], [6, 8], [7, 8], [8, 9], [5, 8], [1, 5],
-    [2, 5], [3, 6], [4, 7], [1, 6], [2, 7], [0, 5]
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
+    [5,6],[5,7],[6,7],[6,8],[7,8],[8,9],[5,8],[1,5],
+    [2,5],[3,6],[4,7],[1,6],[2,7],[0,5]
   ];
 }
 
-// L3 Fibonacci curve: static polyline log spiral
+// L3 Fibonacci curve: static polyline log spiral with 99 calm points.
 function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
+  const phi = (1 + Math.sqrt(5)) / 2;
   const centerX = w / 2;
   const centerY = h / 2;
   const scale = Math.min(w, h) / NUM.THIRTYTHREE;
   const maxRadius = Math.hypot(w, h) / 2;
 
+  ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   ctx.lineJoin = "round";
   ctx.beginPath();
-  for (let i = 0; i < NUM.NINETYNINE; i++) { // 99 static points for trauma-safe predictability
   for (let i = 0; i < NUM.NINETYNINE; i++) {
-    const angle = i * (Math.PI / NUM.ELEVEN); // gentle sweep
-    const r = Math.min(maxRadius, scale * Math.pow(phi, i / NUM.NINE));
-    const x = centerX + r * Math.cos(angle);
-    const y = centerY + r * Math.sin(angle);
+    const angle = i * (Math.PI / NUM.ELEVEN); // gentle sweep tied to 11.
+    const radius = Math.min(maxRadius, scale * Math.pow(phi, i / NUM.NINE));
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
+  ctx.restore();
 }
 
-// L4 Double-helix lattice: two phase-shifted sine waves with 144 struts
+// L4 Double-helix lattice: two sine strands with 144 vertical struts.
 function drawHelix(ctx, w, h, colors, NUM) {
   const centerY = h / 2;
-  const amp = h / NUM.THREE; // amplitude linked to threefold nature
-  const steps = NUM.ONEFORTYFOUR; // lattice count
-  const span = steps - 1 || 1; // ensures the final strut reaches the far edge without extra lines
-  const freq = NUM.THREE; // three full twists
-  const spacing = w / steps;
+  const amplitude = h / NUM.THREE;
+  const steps = NUM.ONEFORTYFOUR;
+  const frequency = NUM.THREE; // three gentle twists across the width.
 
-  // vertical struts connecting the two strands
   ctx.save();
+
   ctx.strokeStyle = colors.lattice;
   ctx.lineWidth = 1;
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI;
-  ctx.globalAlpha = 0.65; // translucent struts keep focus on calm strands
+  ctx.globalAlpha = 0.6; // ND-safe translucency keeps lattice supportive, not overpowering.
   for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI;
-    const y1 = centerY + amp * Math.sin(phase);
-    const y2 = centerY + amp * Math.sin(phase + Math.PI);
+    const ratio = steps === 0 ? 0 : i / steps;
+    const x = ratio * w;
+    const phase = ratio * frequency * Math.PI;
+    const yA = centerY + amplitude * Math.sin(phase);
+    const yB = centerY + amplitude * Math.sin(phase + Math.PI);
     ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
+    ctx.moveTo(x, yA);
+    ctx.lineTo(x, yB);
     ctx.stroke();
   }
 
-  // first strand
+  ctx.globalAlpha = 1;
   ctx.strokeStyle = colors.strand;
   ctx.lineWidth = 2;
-  ctx.globalAlpha = 1;
+
   ctx.beginPath();
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI;
   for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI;
-    const y = centerY + amp * Math.sin(phase);
+    const ratio = steps === 0 ? 0 : i / steps;
+    const x = ratio * w;
+    const phase = ratio * frequency * Math.PI;
+    const y = centerY + amplitude * Math.sin(phase);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
 
-  // second strand phase-shifted by PI
   ctx.beginPath();
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI + Math.PI;
   for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI + Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI + Math.PI;
-    const y = centerY + amp * Math.sin(phase);
+    const ratio = steps === 0 ? 0 : i / steps;
+    const x = ratio * w;
+    const phase = ratio * frequency * Math.PI + Math.PI;
+    const y = centerY + amplitude * Math.sin(phase);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
+
   ctx.restore();
 }


### PR DESCRIPTION
## Summary
- streamline `index.html` to load palettes with a graceful offline fallback and apply ND-safe styles once
- refactor the helix renderer module into pure, layered drawing routines tied to the numerology constants
- clean up the renderer README to describe the four layers, palette fallback, and ND-safe design choices without duplicates

## Testing
- not run (static HTML/JS renderer only)


------
https://chatgpt.com/codex/tasks/task_e_68c94e896d288328933b048fb30b157e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline-friendly palette loading with graceful fallback and user-facing status messages.
  - Accessibility: live status announcements for loading updates.
  - Consistent color application via centralized palette handling.

- Refactor
  - Updated color layering model and defaults for more coherent visuals.
  - Refined rendering: 7×11 grid guides, recalibrated Tree-of-Life layout, smoother Fibonacci curve, and a two-strand double-helix with 144 struts and tuned translucency.

- Documentation
  - Clarified wording, formatting, and usage (including palette fetch caveats and terminology updates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->