### PR TITLE
Refine ND-safe helix renderer

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -1,41 +1,35 @@
-Per Texturas Numerorum, Spira Loquitur.  //
 # Cosmic Helix Renderer
 
-Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This replaces the earlier broken helix demo with a modern, pure ES module version.
+Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This version aligns with the trauma-informed Cosmogenesis plan using pure ES modules and zero external dependencies.
 
-The HTML file works directly from disk: if the palette JSON cannot be read because of local browser restrictions, the module applies a calm fallback palette and the header status line explains why. No network calls leave the machine.
+The HTML file works directly from disk. If the palette JSON cannot be read because of browser file restrictions or missing data, the module applies a calm fallback palette and the header status line explains why. No network calls leave the machine.
 
 ## Layers
-1. **Vesica field** - intersecting circles establishing the sacred lens.
-2. **Tree-of-Life scaffold** - 10 sephirot and 22 paths drawn with calm symmetry.
-3. **Fibonacci curve** - static log spiral approximated with 99 points.
-4. **Double-helix lattice** - two phase-shifted sine strands with 144 vertical struts.
+1. **Vesica field** &mdash; intersecting circles and a gentle vesica grid (Layer 1).
+2. **Tree-of-Life scaffold** &mdash; 10 sephirot and 22 paths, balanced across three pillars (Layer 2).
+3. **Fibonacci curve** &mdash; static logarithmic spiral approximated with 99 points (Layer 3).
+4. **Double-helix lattice** &mdash; two phase-shifted strands linked by 144 struts (Layer 4).
 
 ## Palette
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing, the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
+Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. The active palette also updates page colors to keep contrast consistent with ND-safe guidelines. Additional palettes can be curated later without changing the rendering code.
 
-Default palette hues follow the trauma-informed guidance from the master plan: calm blues, restorative greens, mystical purples, and warm neutrals. All hues appear as high-contrast yet gentle strokes layered over the dark canvas.
+Default palette hues follow the trauma-informed guidance from the cosmic brief: calm blues, restorative greens, mystical purples, and warm neutrals. All hues appear as high-contrast yet gentle strokes layered over the dark canvas.
 
-## ND-Safe Choices
+## ND-safe Choices
 - No animation, motion, or autoplay.
-- High-contrast yet soft color palette.
-- Simple ES module with no network requests.
+- High-contrast yet soft color palette with predictable layering.
+- Simple ES module, offline-first. No build steps or workflows required.
 
-## Numerology
+## Numerology Anchors
 The geometry routines honor key counts:
-- 3 - primary vesica radius and helix amplitude
-- 7 - vesica grid lines
-- 9 - spiral growth factor
-- 11 - vertical rhythm for the Tree of Life
-- 22 - sephirot paths
-- 33 - scaling reference for the spiral
-- 99 - points along the Fibonacci curve
-- 144 - helix lattice struts
+- 3 &mdash; primary vesica radius, helix amplitude, and wave frequency.
+- 7 &mdash; vesica grid columns.
+- 9 &mdash; spiral growth cadence.
+- 11 &mdash; vertical rhythm for the Tree of Life and spiral angle increments.
+- 22 &mdash; sephirot paths.
+- 33 &mdash; spiral scaling baseline.
+- 99 &mdash; points along the Fibonacci curve.
+- 144 &mdash; helix lattice struts.
 
 ## Usage
-Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features.
-
-No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.
-Open `index.html` directly in any modern browser. The canvas is 1440x900 and uses only built-in browser features.
+Open `index.html` directly in any modern browser. The canvas is 1440x900 and relies only on built-in browser features. The header status line will report whether the custom palette loaded or if the safe fallback is in use.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -1,4 +1,3 @@
-<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
 <!doctype html>
 <html lang="en">
 <head>
@@ -10,8 +9,8 @@
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root {
       --bg:#0b0b12;
-      --ink:#e5e5ea;
-      --muted:#7f86a6;
+      --ink:#e8e8f0;
+      --muted:#a6a6c1;
       --frame:#1d1d2a;
     }
     html,body {
@@ -49,90 +48,27 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
     <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    function getMutedColor(palette) {
-      // ND-safe: keep interface text gentle even if palette omits a muted tone.
-      const fallback = "#a6a6c1";
-      const layerTone = palette.layers && palette.layers[5];
-      return layerTone || fallback;
-    }
-
-    async function loadJSON(path) {
-      // Offline-friendly: swallow file errors and fall back to defaults without alerts.
-    async function loadPalette(path) {
-      const isFile = window.location.protocol === "file:";
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        const data = await res.json();
-        return { data, message: "Palette loaded from data file." };
-      } catch (err) {
-        const reason = isFile ? "Browser blocked file fetch;" : "Palette file missing;";
-        return { data: null, message: reason + " using safe fallback palette." };
-      }
-    }
-
-    function applyPalette(palette) {
-      const root = document.documentElement;
-      root.style.setProperty("--bg", palette.bg);
-      root.style.setProperty("--ink", palette.ink);
-      root.style.setProperty("--muted", palette.muted || palette.ink);
-      document.body.style.background = palette.bg;
-      document.body.style.color = palette.ink;
-    }
-
     const defaults = {
       bg:"#0b0b12",
-      ink:"#e5e5ea",
-      muted:"#7f86a6",
+      ink:"#e8e8f0",
+      muted:"#a6a6c1",
       layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-
-    // Apply palette once for calm, readable contrast (why: ND-safe colors)
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-    const muted = getMutedColor(active);
-    const rootStyle = document.documentElement.style;
-    // ND-safe: apply palette to the entire page for consistent contrast and calm focus.
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    rootStyle.setProperty("--muted", muted);
-    const rootStyle = document.documentElement.style; // sync page colors with palette
-    rootStyle.setProperty("--bg", active.bg);
-    rootStyle.setProperty("--ink", active.ink);
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-    const paletteResult = await loadPalette("./data/palette.json");
-    const activePalette = paletteResult.data || defaults;
-    applyPalette(activePalette);
-    elStatus.textContent = paletteResult.message;
-    const statusMessage = palette ? "Palette loaded." : "Palette not available; using safe fallback.";
-    elStatus.textContent = statusMessage;
-
-    // Update CSS variables so the surrounding page honors the active palette.
-    const root = document.documentElement;
-    root.style.setProperty("--bg", active.bg);
-    root.style.setProperty("--ink", active.ink);
-
-    // Numerology constants used by geometry routines
     const NUM = {
       THREE:3,
       SEVEN:7,
@@ -144,18 +80,51 @@
       ONEFORTYFOUR:144
     };
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable; geometry skipped.";
-    } else {
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    function updateStatus(message) {
+      statusEl.textContent = message;
     }
-    renderHelix(ctx, {
-      width:canvas.width,
-      height:canvas.height,
-      palette:activePalette,
-      NUM
-    });
+
+    function applyPalette(palette) {
+      const bg = palette.bg || defaults.bg;
+      const ink = palette.ink || defaults.ink;
+      const muted = palette.muted || defaults.muted;
+      const root = document.documentElement.style;
+      root.setProperty("--bg", bg);
+      root.setProperty("--ink", ink);
+      root.setProperty("--muted", muted);
+      document.body.style.background = bg;
+      document.body.style.color = ink;
+    }
+
+    async function loadPalette(path) {
+      const isFile = window.location.protocol === "file:";
+      try {
+        const res = await fetch(path, { cache:"no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        const data = await res.json();
+        return { palette:data, note:"Palette loaded from data file." };
+      } catch (err) {
+        const reason = isFile ? "Browser blocked local file fetch" : "Palette file missing";
+        return { palette:null, note:reason + "; using safe fallback palette." };
+      }
+    }
+
+    async function init() {
+      const paletteInfo = await loadPalette("./data/palette.json");
+      const active = paletteInfo.palette || defaults;
+      applyPalette(active);
+
+      if (!ctx) {
+        updateStatus(paletteInfo.note + " Canvas context unavailable; geometry skipped.");
+        return;
+      }
+
+      // ND-safe rationale: rendering happens once, layering preserves depth without motion.
+      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+      updateStatus(paletteInfo.note + " Geometry rendered.");
+    }
+
+    init();
   </script>
 </body>
 </html>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -1,102 +1,99 @@
-// Per Texturas Numerorum, Spira Loquitur.  //
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
   Layers:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
-    3) Fibonacci curve (log spiral polyline; static)
-    4) Double-helix lattice (two phase-shifted sine strands with 144 vertical struts)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
+    4) Double-helix lattice (two phase-shifted strands with 144 struts)
 */
 
-// Small, pure, parameterized functions only; no animation, no external deps.
-// ND-safe: all drawings are static with high-contrast, calm palette.
+// Small, pure, parameterized functions only; no animation, no external dependencies.
+// ND-safe: all drawings are static with layered order for calm focus.
 
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
-  const colors = palette.layers || [];
+  const layers = Array.isArray(palette.layers) ? palette.layers : [];
+  const ink = palette.ink || "#e8e8f0";
 
+  // Layer foundation: fill background first to anchor the canvas in calm darkness.
   ctx.save();
-  ctx.fillStyle = palette.bg;
+  ctx.fillStyle = palette.bg || "#0b0b12";
   ctx.fillRect(0, 0, width, height);
   ctx.restore();
 
   drawVesica(ctx, width, height, {
-    rim: pickColor(colors, 0, palette.ink),
-    grid: pickColor(colors, 1, palette.ink)
+    rim: pickColor(layers, 0, ink),
+    grid: pickColor(layers, 1, ink)
   }, NUM);
+
   drawTree(ctx, width, height, {
-    path: pickColor(colors, 2, palette.ink),
-    node: pickColor(colors, 3, palette.ink)
+    path: pickColor(layers, 2, ink),
+    node: pickColor(layers, 3, ink)
   }, NUM);
-  drawFibonacci(ctx, width, height, pickColor(colors, 4, palette.ink), NUM);
+
+  drawFibonacci(ctx, width, height, pickColor(layers, 4, ink), NUM);
+
   drawHelix(ctx, width, height, {
-    strand: pickColor(colors, 5, palette.ink),
-    lattice: pickColor(colors, 0, palette.ink)
+    strand: pickColor(layers, 5, ink),
+    lattice: pickColor(layers, 0, ink)
   }, NUM);
 }
 
-  // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix crown.
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
 function pickColor(list, index, fallback) {
-  return list && list[index] ? list[index] : fallback;
+  return list[index] || fallback;
 }
 
-// L1 Vesica field: soft intersecting circles, gentle grid
-function drawVesica(ctx, w, h, colors, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // radius tied to numerology
+// L1 Vesica field: intersecting circles and a gentle grid grounded in numerology.
+function drawVesica(ctx, w, h, tones, NUM) {
+  const radius = Math.min(w, h) / NUM.THREE;
   const cx = w / 2;
   const cy = h / 2;
 
   ctx.save();
-  ctx.strokeStyle = colors.rim;
+  ctx.strokeStyle = tones.rim;
   ctx.lineWidth = 2;
   ctx.beginPath();
-  ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
-  ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
+  ctx.arc(cx - radius / 2, cy, radius, 0, Math.PI * 2);
+  ctx.arc(cx + radius / 2, cy, radius, 0, Math.PI * 2);
   ctx.stroke();
 
-  // subtle vesica grid using SEVEN vertical lines + ELEVEN horizontal guides
+  ctx.strokeStyle = tones.grid;
   ctx.lineWidth = 1;
-  ctx.strokeStyle = colors.grid;
-  ctx.globalAlpha = 0.6; // ND-safe translucency to keep the grid gentle
-  const step = r / NUM.SEVEN;
+  ctx.globalAlpha = 0.5; // ND-safe translucency keeps the grid supportive, not overwhelming.
+
+  const verticalStep = radius / NUM.SEVEN;
   ctx.beginPath();
   for (let i = -NUM.SEVEN; i <= NUM.SEVEN; i++) {
-    const x = cx + i * step;
-    ctx.moveTo(x, cy - r);
-    ctx.lineTo(x, cy + r);
+    const x = cx + i * verticalStep;
+    ctx.moveTo(x, cy - radius);
+    ctx.lineTo(x, cy + radius);
   }
   ctx.stroke();
 
-  const horizonStep = r / NUM.ELEVEN;
+  const horizontalStep = (radius * 2) / NUM.ELEVEN;
   ctx.beginPath();
-  for (let j = -NUM.ELEVEN; j <= NUM.ELEVEN; j += NUM.SEVEN) {
-    const y = cy + j * horizonStep;
-    ctx.moveTo(cx - r, y);
-    ctx.lineTo(cx + r, y);
+  for (let j = 0; j <= NUM.ELEVEN; j++) {
+    const y = cy - radius + j * horizontalStep;
+    ctx.moveTo(cx - radius, y);
+    ctx.lineTo(cx + radius, y);
   }
-  ctx.moveTo(cx - r, cy);
-  ctx.lineTo(cx + r, cy);
   ctx.stroke();
   ctx.restore();
 }
 
-// L2 Tree-of-Life: 10 nodes + 22 paths (NUM.TWENTYTWO)
-function drawTree(ctx, w, h, colors, NUM) {
-  const stepY = h / NUM.ELEVEN; // vertical rhythm
+// L2 Tree-of-Life scaffold: 10 nodes and 22 paths for steady ascent.
+function drawTree(ctx, w, h, tones, NUM) {
+  const stepY = h / NUM.ELEVEN;
   const xCenter = w / 2;
-  const xOffset = w / NUM.THREE / 2; // three pillars
+  const xOffset = w / NUM.THREE / 2; // Three pillars define lateral spacing.
 
   const nodes = buildTreeNodes(xCenter, xOffset, stepY);
   const paths = buildTreePaths();
 
   ctx.save();
-  ctx.strokeStyle = colors.path;
+  ctx.strokeStyle = tones.path;
   ctx.lineWidth = 1;
   ctx.lineCap = "round";
   for (const [a, b] of paths) {
@@ -108,129 +105,109 @@ function drawTree(ctx, w, h, colors, NUM) {
     ctx.stroke();
   }
 
-  const r = Math.min(w, h) / NUM.THREE / NUM.ELEVEN; // small node radius
-  ctx.fillStyle = colors.node;
-  for (const n of nodes) {
+  const nodeRadius = Math.min(w, h) / (NUM.THREE * NUM.ELEVEN);
+  ctx.fillStyle = tones.node;
+  for (const node of nodes) {
     ctx.beginPath();
-    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
   }
   ctx.restore();
 }
 
-function buildTreeNodes(xCenter, xOffset, stepY) {
+function buildTreeNodes(center, offset, stepY) {
+  // Ten sephirot arranged in tri-column symmetry.
   return [
-    { x: xCenter, y: stepY },
-    { x: xCenter + xOffset, y: stepY * 2 },
-    { x: xCenter - xOffset, y: stepY * 2 },
-    { x: xCenter + xOffset, y: stepY * 4 },
-    { x: xCenter - xOffset, y: stepY * 4 },
-    { x: xCenter, y: stepY * 5 },
-    { x: xCenter + xOffset, y: stepY * 7 },
-    { x: xCenter - xOffset, y: stepY * 7 },
-    { x: xCenter, y: stepY * 8 },
-    { x: xCenter, y: stepY * 10 }
+    { x:center, y:stepY },
+    { x:center + offset, y:stepY * 2 },
+    { x:center - offset, y:stepY * 2 },
+    { x:center + offset, y:stepY * 4 },
+    { x:center - offset, y:stepY * 4 },
+    { x:center, y:stepY * 5 },
+    { x:center + offset, y:stepY * 7 },
+    { x:center - offset, y:stepY * 7 },
+    { x:center, y:stepY * 8 },
+    { x:center, y:stepY * 10 }
   ];
 }
 
 function buildTreePaths() {
+  // Twenty-two paths honoring the classic Tree-of-Life connections.
   return [
-    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
-    [5, 6], [5, 7], [6, 7], [6, 8], [7, 8], [8, 9], [5, 8], [1, 5],
-    [2, 5], [3, 6], [4, 7], [1, 6], [2, 7], [0, 5]
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
+    [5,6],[5,7],[6,7],[6,8],[7,8],[8,9],[5,8],[1,5],
+    [2,5],[3,6],[4,7],[1,6],[2,7],[0,5]
   ];
 }
 
-// L3 Fibonacci curve: static polyline log spiral
+// L3 Fibonacci curve: 99 static points create a calm logarithmic spiral.
 function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
+  const phi = (1 + Math.sqrt(5)) / 2;
   const centerX = w / 2;
   const centerY = h / 2;
   const scale = Math.min(w, h) / NUM.THIRTYTHREE;
   const maxRadius = Math.hypot(w, h) / 2;
 
+  ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   ctx.lineJoin = "round";
   ctx.beginPath();
-  for (let i = 0; i < NUM.NINETYNINE; i++) { // 99 static points for trauma-safe predictability
   for (let i = 0; i < NUM.NINETYNINE; i++) {
-    const angle = i * (Math.PI / NUM.ELEVEN); // gentle sweep
-    const r = Math.min(maxRadius, scale * Math.pow(phi, i / NUM.NINE));
-    const x = centerX + r * Math.cos(angle);
-    const y = centerY + r * Math.sin(angle);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-}
-
-// L4 Double-helix lattice: two phase-shifted sine waves with 144 struts
-function drawHelix(ctx, w, h, colors, NUM) {
-  const centerY = h / 2;
-  const amp = h / NUM.THREE; // amplitude linked to threefold nature
-  const steps = NUM.ONEFORTYFOUR; // lattice count
-  const span = steps - 1 || 1; // ensures the final strut reaches the far edge without extra lines
-  const freq = NUM.THREE; // three full twists
-  const spacing = w / steps;
-
-  // vertical struts connecting the two strands
-  ctx.save();
-  ctx.strokeStyle = colors.lattice;
-  ctx.lineWidth = 1;
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI;
-  ctx.globalAlpha = 0.65; // translucent struts keep focus on calm strands
-  for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI;
-    const y1 = centerY + amp * Math.sin(phase);
-    const y2 = centerY + amp * Math.sin(phase + Math.PI);
-    ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
-    ctx.stroke();
-  }
-
-  // first strand
-  ctx.strokeStyle = colors.strand;
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 1;
-  ctx.beginPath();
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI;
-  for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI;
-    const y = centerY + amp * Math.sin(phase);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // second strand phase-shifted by PI
-  ctx.beginPath();
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = w * ratio;
-    const phase = ratio * freq * Math.PI + Math.PI;
-  for (let i = 0; i <= steps; i++) {
-    const x = spacing * i;
-    const phase = (i / steps) * freq * Math.PI + Math.PI;
-    const x = (w / (steps - 1)) * i;
-    const phase = (i / (steps - 1)) * freq * Math.PI + Math.PI;
-    const y = centerY + amp * Math.sin(phase);
+    const angle = i * (Math.PI / NUM.ELEVEN);
+    const radius = Math.min(maxRadius, scale * Math.pow(phi, i / NUM.NINE));
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
   ctx.stroke();
   ctx.restore();
+}
+
+// L4 Double-helix lattice: twin strands bridged by 144 static struts.
+function drawHelix(ctx, w, h, tones, NUM) {
+  const steps = NUM.ONEFORTYFOUR;
+  const span = Math.max(1, steps - 1);
+  const baseY = h / 2;
+  const amplitude = h / NUM.THREE;
+  const frequency = NUM.THREE; // Three full waves maintain the trifold pattern.
+
+  ctx.save();
+
+  ctx.strokeStyle = tones.lattice;
+  ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.55; // Struts stay supportive without overpowering the strands.
+  for (let i = 0; i < steps; i++) {
+    const ratio = i / span;
+    const x = ratio * w;
+    const phase = ratio * frequency * Math.PI;
+    const yA = baseY + amplitude * Math.sin(phase);
+    const yB = baseY + amplitude * Math.sin(phase + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, yA);
+    ctx.lineTo(x, yB);
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = 1;
+  ctx.strokeStyle = tones.strand;
+  ctx.lineWidth = 2;
+  drawStrand(ctx, steps, span, w, baseY, amplitude, frequency, 0);
+  drawStrand(ctx, steps, span, w, baseY, amplitude, frequency, Math.PI);
+
+  ctx.restore();
+}
+
+function drawStrand(ctx, steps, span, width, baseY, amplitude, frequency, phaseShift) {
+  ctx.beginPath();
+  for (let i = 0; i < steps; i++) {
+    const ratio = i / span;
+    const x = ratio * width;
+    const phase = ratio * frequency * Math.PI + phaseShift;
+    const y = baseY + amplitude * Math.sin(phase);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
 }


### PR DESCRIPTION
## Summary
- rebuild the offline helix index page with a clean palette fallback, numerology constants, and ND-safe messaging
- rework the renderer module into static, layered drawing functions for vesica, tree, spiral, and double-helix geometry
- refresh the renderer README to document layers, palette handling, and numerology anchors

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68c951ad888483289a440104fe57a749