### PR TITLE
Restructure static site for Netlify deploy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 *.png  filter=lfs diff=lfs merge=lfs -text
-*.tif  filter=lfs diff=lfs merge=lfs -text
-*.tiff filter=lfs diff=lfs merge=lfs -text
-*.exr  filter=lfs diff=lfs merge=lfs -text
-*.hdr  filter=lfs diff=lfs merge=lfs -text
+*.jpg  filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
+*.avif filter=lfs diff=lfs merge=lfs -text

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+[build]
+  publish = "site"
+  command = ""
+  [build.environment]
+    GIT_LFS_ENABLED = "true"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy = "default-src 'self' https: data:; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; script-src 'self' https:; connect-src 'self' https:; frame-ancestors 'none';"

--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -1,0 +1,243 @@
+/* Atelier theme: calm contrast, ND-safe palette */
+:root {
+  --ink: #f1f1ff;
+  --ink-muted: #c0c0d9;
+  --canvas: #0c0c13;
+  --accent: #8f9bff;
+  --accent-soft: #3741a0;
+  --accent-warm: #f5ad7d;
+  --border: #1e1e2d;
+  --body-font: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+/* Reduced motion toggle uses class on <html> */
+html {
+  color-scheme: dark;
+}
+
+html.reduced-motion *,
+html.reduced-motion *::before,
+html.reduced-motion *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #141427, var(--canvas));
+  color: var(--ink);
+  font: 16px/1.6 var(--body-font);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--ink);
+}
+
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 16px;
+  padding: 0.5rem 0.75rem;
+  background: var(--accent);
+  color: var(--canvas);
+  border-radius: 0.5rem;
+  z-index: 10;
+  transition: top 0.3s ease;
+}
+
+.skip-link:focus {
+  top: 12px;
+}
+
+.atelier-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.2rem 2rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(12, 12, 19, 0.95);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+}
+
+.marque-logo {
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.nav-collection {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.nav-collection li a {
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.nav-collection li a:hover,
+.nav-collection li a:focus {
+  border-color: var(--accent);
+  background: rgba(143, 155, 255, 0.12);
+}
+
+.btn-couture {
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.btn-couture:hover,
+.btn-couture:focus {
+  background: var(--accent-soft);
+}
+
+main {
+  padding: 2rem 2.5rem 4rem;
+  display: grid;
+  gap: 3rem;
+}
+
+.hero {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero-visual {
+  background: rgba(20, 20, 35, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.35);
+}
+
+.hero-visual img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.hero-copy {
+  padding: 1rem;
+}
+
+.hero-copy h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  letter-spacing: 0.08em;
+}
+
+.hero-copy p {
+  margin: 0.5rem 0 0;
+  color: var(--ink-muted);
+}
+
+.section {
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  background: rgba(15, 15, 26, 0.85);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+.section h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 1.25rem;
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: rgba(18, 18, 30, 0.85);
+}
+
+.card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--ink-muted);
+}
+
+.maison-footer {
+  padding: 2rem 2.5rem 3rem;
+  border-top: 1px solid var(--border);
+  background: rgba(10, 10, 18, 0.95);
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.footer-marque {
+  font-weight: 700;
+  letter-spacing: 0.2em;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-links a {
+  font-size: 0.95rem;
+  color: var(--ink-muted);
+}
+
+.footer-links a:hover,
+.footer-links a:focus {
+  color: var(--ink);
+}
+
+@media (max-width: 720px) {
+  .atelier-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .btn-couture {
+    width: 100%;
+  }
+
+  main {
+    padding: 1.5rem;
+  }
+}

--- a/site/assets/img/hero.avif
+++ b/site/assets/img/hero.avif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57160f8e8bee257dd6ac0501e4e8362f9bb4de699a2c9efbe128be3e127397bb
+size 87297

--- a/site/assets/js/calm.js
+++ b/site/assets/js/calm.js
@@ -1,0 +1,6 @@
+const prefersReduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+if (prefersReduced) document.documentElement.classList.add('reduced-motion');
+document.getElementById('calmToggle')?.addEventListener('click', () => {
+  const active = document.documentElement.classList.toggle('reduced-motion');
+  document.getElementById('calmToggle').setAttribute('aria-pressed', String(active));
+});

--- a/site/assets/js/nodes.js
+++ b/site/assets/js/nodes.js
@@ -1,0 +1,50 @@
+// nodes.js — offline-first loader for node registry
+const grid = document.getElementById('nodeGrid');
+const source = '../data/nodes.json';
+
+/**
+ * Create the HTML markup for a node card.
+ * Small pure function keeps rendering predictable and readable.
+ */
+function renderCard(node) {
+  return `
+    <article class="card" role="listitem">
+      <h3>${node.title}</h3>
+      <p>${node.summary}</p>
+    </article>
+  `;
+}
+
+/**
+ * Render a friendly fallback message when data is unavailable.
+ */
+function renderFallback(message) {
+  grid.innerHTML = `
+    <article class="card" role="listitem">
+      <h3>Node registry offline</h3>
+      <p>${message}</p>
+    </article>
+  `;
+}
+
+async function loadNodes() {
+  if (!grid) return;
+  try {
+    const response = await fetch(source, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    const payload = await response.json();
+    const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    if (!nodes.length) {
+      renderFallback('No nodes registered yet. Calm archives will populate soon.');
+      return;
+    }
+    grid.innerHTML = nodes.map(renderCard).join('');
+  } catch (error) {
+    console.warn('Node registry could not load.', error);
+    renderFallback('Local data missing. Check data/nodes.json for updates.');
+  }
+}
+
+loadNodes();

--- a/site/data/nodes.json
+++ b/site/data/nodes.json
@@ -1,0 +1,16 @@
+{
+  "nodes": [
+    {
+      "title": "Node 03 - Harmonic Crucible",
+      "summary": "Triadic resonance field exploring vesica alignments and calm chromatics for studio rituals."
+    },
+    {
+      "title": "Node 09 - Choir of Circuits",
+      "summary": "Choral study of tarot correspondences mapped to circuit sigils with printable overlays."
+    },
+    {
+      "title": "Node 22 - Spiral Archive",
+      "summary": "Offline-first library of Fibonacci spirals, double-helix notes, and workshop prompts."
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>COSMOGENESIS — Cathedral of Circuits</title>
+  <meta name="description" content="A living grimoire: sacred geometry, techno-occult research, and spiral learning." />
+  <link rel="preload" href="assets/img/hero.avif" as="image" />
+  <link rel="stylesheet" href="assets/css/atelier.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <nav class="atelier-nav">
+    <a href="#collections" class="marque-logo">COSMOGENESIS</a>
+    <ul class="nav-collection">
+      <li><a href="#collections">Collections</a></li>
+      <li><a href="#arcana">Living Arcana</a></li>
+      <li><a href="#node-system">Node System</a></li>
+      <li><a href="#atelier">Atelier</a></li>
+    </ul>
+    <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
+  </nav>
+
+  <main id="main">
+    <section class="hero" aria-labelledby="hero-title">
+      <figure class="hero-visual">
+        <img src="assets/img/hero.avif" width="1280" height="720" alt="Layered circuit sigil with calm indigo gradient." />
+      </figure>
+      <div class="hero-copy">
+        <h1 id="hero-title">Cathedral of Circuits</h1>
+        <p>Spiral learning meets sacred geometry. The atelier is ND-safe, slow crafted, and focused on layered depth rather than spectacle.</p>
+        <p>Calm Mode keeps transitions soft for sensory ease. Reduced motion is always respected for visitors who prefer stillness.</p>
+      </div>
+    </section>
+
+    <section class="section" id="collections" aria-labelledby="collections-title">
+      <h2 id="collections-title">Collections</h2>
+      <p>Harmonic folios curated for different entry points into the cathedral. Every collection balances geometry, lore, and quiet research.</p>
+      <div class="grid" role="list">
+        <article class="card" role="listitem">
+          <h3>Vesica Vault</h3>
+          <p>Archetypal diagrams and meditations anchored by the vesica piscis lattice. Gentle overlays guide the eye without motion.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>Arc Forge</h3>
+          <p>Research journals mapping circuitry to tarot correspondences. Includes sensor-friendly palettes and layered annotations.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>Helix Atlas</h3>
+          <p>Double helix studies cross-referenced with Fibonacci harmonics. Built for offline study circles and workshop tables.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="arcana" aria-labelledby="arcana-title">
+      <h2 id="arcana-title">Living Arcana</h2>
+      <p>Interactive folios maintain one-to-one parity with the tarot lineage. Nodes are annotated with sensory-safe rituals and optional research paths.</p>
+      <div class="grid" role="list">
+        <article class="card" role="listitem">
+          <h3>Zero - Aurora Gate</h3>
+          <p>Entry sequence for seekers. Offers narrative, game, art, and research lenses without autoplay or sudden motion.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>XI - Circuit Choir</h3>
+          <p>Focuses on harmonic resonance. Includes printable overlays and accessible annotations for collaborative study.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>XXII - Resonant Crown</h3>
+          <p>Finale of the spiral, combining geometry renders with gentle text layers. Calibrated for mindful pacing.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="node-system" aria-labelledby="node-title">
+      <h2 id="node-title">Node System</h2>
+      <p>The node registry keeps track of living research threads. Data loads locally from <code>data/nodes.json</code> so the atlas stays offline-first.</p>
+      <div id="nodeGrid" class="grid" role="list" aria-live="polite"></div>
+    </section>
+
+    <section class="section" id="atelier" aria-labelledby="atelier-title">
+      <h2 id="atelier-title">Atelier</h2>
+      <p>Commission portals, learning labs, and calm prototypes. Void Lab remains the testing chamber for new experiments.</p>
+      <div class="grid" role="list">
+        <article class="card" role="listitem">
+          <h3>Calm Kits</h3>
+          <p>Printable rituals and sensory-friendly overlays for facilitators. Each kit includes annotations for ND needs.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>Node Workshops</h3>
+          <p>Hands-on sessions exploring sacred geometry with layered canvases. No projectors, no flashing lights-just mindful study.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3>Void Lab</h3>
+          <p><a href="labs/void-lab.html">Enter the void lab</a> to inspect prototypes, view patch notes, and submit feedback without leaving the offline sanctuary.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="maison-footer">
+    <div class="footer-marque">COSMOGENESIS</div>
+    <div class="footer-links">
+      <a href="#collections">Harmonic Research</a>
+      <a href="#node-system">Node System Docs</a>
+      <a href="https://github.com/your-org/your-repo" rel="noopener noreferrer">Open Source</a>
+      <a href="#atelier">Commissions</a>
+    </div>
+    <p class="copyright">© MMXXV - Cathedral of Circuits</p>
+  </footer>
+
+  <script type="module" src="assets/js/calm.js"></script>
+  <script type="module" src="assets/js/nodes.js"></script>
+</body>
+</html>

--- a/site/labs/void-lab.html
+++ b/site/labs/void-lab.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Void Lab - Calm Experiments</title>
+  <link rel="stylesheet" href="../assets/css/atelier.css" />
+</head>
+<body>
+  <a class="skip-link" href="#lab">Skip to content</a>
+  <nav class="atelier-nav">
+    <a href="../index.html" class="marque-logo">COSMOGENESIS</a>
+    <ul class="nav-collection">
+      <li><a href="../index.html#collections">Collections</a></li>
+      <li><a href="../index.html#arcana">Living Arcana</a></li>
+      <li><a href="../index.html#node-system">Node System</a></li>
+      <li><a href="../index.html#atelier">Atelier</a></li>
+    </ul>
+    <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
+  </nav>
+
+  <main id="lab" class="section" style="margin: 3rem auto; max-width: 960px;">
+    <h1>Void Lab</h1>
+    <p>This chamber hosts prototypes before they graduate into the wider cathedral. Everything is static, offline, and sensory friendly.</p>
+    <p>Bring questions, annotations, and requests. Void Lab supports calm reviews of layered geometry without any motion or autoplay.</p>
+    <ul>
+      <li>Patch drafts for new tarot nodes</li>
+      <li>Palette accessibility reviews</li>
+      <li>Requests for printed overlays</li>
+    </ul>
+    <p><a href="../index.html">Return to the main atelier</a></p>
+  </main>
+
+  <footer class="maison-footer">
+    <div class="footer-marque">COSMOGENESIS</div>
+    <p class="copyright">© MMXXV - Cathedral of Circuits</p>
+  </footer>
+
+  <script type="module" src="../assets/js/calm.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `site/` publish directory with the calm atelier landing page, supporting CSS/JS, nodes data, and void lab stub
- configure Netlify to publish the `site` directory with strict security headers and enable Git LFS for binary assets
- update `.gitattributes` for image tracking and add the optimized hero artwork via LFS

## Testing
- npm test *(fails: SyntaxError: Unexpected token 'export' in engines/interface-guard.js when running existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cc51b5f8588328a208a62f13efc847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New static homepage with hero, collections, living arcana, node system, and atelier sections.
  - Dynamic, offline-first node list loaded from local data.
  - “Calm Mode” toggle honoring reduced-motion preferences.
  - New “Void Lab” page for calm, offline experiments.

- Style
  - New Atelier theme: accessible dark palette, responsive layout, improved navigation, cards, and CTAs.

- Chores
  - Netlify deployment configured with strict security headers.
  - Image asset handling updated via Git LFS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->