### PR TITLE
feat: add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,35 @@
+# Cosmic Helix Renderer
+
+Static, offline-safe renderer for the Cathedral lattice. Double-click `index.html` and the 1440×900 canvas will layer sacred geometry without motion.
+
+## Features
+
+- **Layer order** (ND-safe): Vesica field → Tree-of-Life scaffold → Fibonacci curve → Double-helix lattice.
+- **Palette aware:** reads `data/palette.json` via native ES modules; if blocked (e.g., local file restrictions) it falls back to a built-in ND-safe palette and shows a status notice.
+- **Numerology alignment:** geometry dimensions reference the constants 3, 7, 9, 11, 22, 33, 99, and 144 for spacing and repetitions.
+- **Offline-first:** no network calls; everything lives inside `/index.html`, `/js/helix-renderer.mjs`, and `/data/palette.json`.
+
+## Files
+
+- `index.html` — entry point with ND-safe styles, wireframe lattice backdrop, luminous node halo, and renderer bootstrapping.
+- `js/helix-renderer.mjs` — pure ES module; exports `renderHelix(ctx, options)` and draws the four layers.
+- `data/palette.json` — optional theme overrides (background, ink, layer colors). If removed, defaults are used.
+
+## Usage
+
+1. Open the repository locally.
+2. Double-click `index.html` (no server required).
+3. Observe status line: "Palette loaded." means JSON was read, otherwise fallback palette is active.
+
+To adjust colors, edit `data/palette.json` (hex values only). Reload the page to apply the tint. The cathedral lattice background listens for custom `cathedral:select` events, so other scripts can retint the wireframe if desired.
+
+## Accessibility & ND Safety
+
+- Zero animation or autoplay; only static gradients and lines.
+- High contrast text (`--ink`) against deep background (`--bg`).
+- Layer comments in the module explain why each step preserves ND safety (soft glows, limited shadow blur).
+- Background and halo color variables respect Codex tint events without introducing motion.
+
+## Extending
+
+If you introduce new data files, keep them under `/data/` and prefer module imports (`import ... assert { type: "json" }`) so the renderer stays offline-friendly. For new geometry layers, follow the same pattern: derive counts from the numerology constants and keep helpers pure and documented.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,6 +1,7 @@
 {
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
+  "muted": "#a6a6c1",
   "layers": [
     "#b1c7ff",
     "#89f7fe",

--- a/index.html
+++ b/index.html
@@ -1,100 +1,224 @@
 <!doctype html>
-<html lang="en" data-codex="144:99" data-app="stone-grimoire">
+<html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>circuitum99 -- Cosmogenesis (Pro)</title>
-  <meta name="description" content="Cosmogenesis Learning Engine: tilted-axis cosmos, spiral nodes, and hermetic overlays. ND-safe." />
-  <link rel="stylesheet" href="./assets/css/core.css" />
-  <script type="module">
-    // single-init guard
-    import { guardInit } from './js/core/guard.js';
-    guardInit('cosmogenesis');
-
-    // theme + engine
-    import { loadStylepacks } from './js/engines/theme-engine.js';
-    import { initCosmogenesis } from './js/engines/cosmogenesis.js';
-
-    (async () => {
-      const stylepacks = await loadStylepacks('./assets/data/stylepacks.json');
-      const canvas = document.getElementById('plate');
-      const ui = {
-        tilt: document.getElementById('tilt'),
-        nodes: document.getElementById('nodes'),
-        palette: document.getElementById('palette'),
-        save: document.getElementById('save'),
-        tiltLabel: document.getElementById('tiltLabel'),
-        nodesLabel: document.getElementById('nodesLabel'),
-      };
-
-      const engine = initCosmogenesis(canvas, stylepacks);
-      // hydrate UI
-      for (const key of Object.keys(stylepacks)) {
-        const opt = document.createElement('option');
-        opt.value = key; opt.textContent = key;
-        ui.palette.appendChild(opt);
-      }
-      // restore persisted
-      const state = engine.getState();
-      ui.tilt.value = state.tilt;
-      ui.nodes.value = state.nodes;
-      ui.palette.value = state.palette;
-      ui.tiltLabel.textContent = state.tilt + '°';
-      ui.nodesLabel.textContent = state.nodes;
-
-      // wire events (gentle updates)
-      ui.tilt.addEventListener('input', e => {
-        ui.tiltLabel.textContent = e.target.value + '°';
-        engine.update({ tilt: parseFloat(e.target.value) });
-      });
-      ui.nodes.addEventListener('input', e => {
-        ui.nodesLabel.textContent = e.target.value;
-        engine.update({ nodes: parseInt(e.target.value, 10) });
-      });
-      ui.palette.addEventListener('change', e => {
-        engine.update({ palette: e.target.value });
-      });
-      ui.save.addEventListener('click', () => engine.savePNG());
-    })();
-  </script>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="dark light">
+  <style>
+    /* ND-safe: calm contrast, static layout, generous spacing */
+    :root {
+      --bg:#0b0b12;
+      --ink:#e8e8f0;
+      --muted:#a6a6c1;
+    }
+    html, body {
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--ink);
+      font:14px/1.5 "Segoe UI", system-ui, -apple-system, Roboto, sans-serif;
+      min-height:100%;
+    }
+    header {
+      padding:16px;
+      border-bottom:1px solid rgba(232,232,240,0.08);
+      background:linear-gradient(180deg, rgba(18,18,26,0.88), rgba(11,11,18,0.66));
+      position:sticky;
+      top:0;
+      backdrop-filter:blur(2px);
+    }
+    header strong {
+      letter-spacing:0.08em;
+      text-transform:uppercase;
+      font-size:13px;
+    }
+    .status {
+      color:var(--muted);
+      font-size:12px;
+      margin-top:4px;
+    }
+    main {
+      padding:24px 16px 40px;
+    }
+    #stage {
+      display:block;
+      margin:0 auto 12px;
+      width:100%;
+      max-width:1440px;
+      height:auto;
+      box-shadow:0 0 0 1px rgba(255,255,255,0.08), 0 24px 64px rgba(0,0,0,0.55);
+      background:radial-gradient(circle at 50% 30%, rgba(255,255,255,0.06), transparent 58%);
+    }
+    .note {
+      max-width:880px;
+      margin:0 auto;
+      color:var(--muted);
+      font-size:13px;
+      text-align:center;
+    }
+    .fallback {
+      color:#f1d27f;
+    }
+  </style>
 </head>
 <body>
-  <div id="nd-settings" style="padding:8px;border-bottom:1px solid #444;max-width:400px;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif">
-    <label>Motion
-      <select id="motion">
-        <option value="reduced" selected>reduced</option>
-        <option value="full">full</option>
-      </select>
-    </label>
-    <label>Autoplay
-      <input type="checkbox" id="autoplay" />
-    </label>
-    <label>Contrast
-      <select id="contrast">
-        <option value="balanced" selected>balanced</option>
-        <option value="high">high</option>
-      </select>
-    </label>
-  </div>
-  <header class="bar">
-    <h1>✦ Cosmogenesis -- Cathedral of Circuits</h1>
-    <div class="controls">
-      <label> Tilt <span id="tiltLabel"></span>
-        <input id="tilt" type="range" min="0" max="45" step="0.5" value="23.5" />
-      </label>
-      <label> Nodes <span id="nodesLabel"></span>
-        <input id="nodes" type="range" min="12" max="144" step="1" value="72" />
-      </label>
-      <label> Palette
-        <select id="palette"></select>
-      </label>
-      <button id="save" aria-label="Save PNG">Save PNG</button>
-    </div>
+  <header>
+    <strong>Cosmic Helix Renderer</strong>
+    <div class="status" id="status">Loading palette…</div>
   </header>
-  <main class="stage">
-    <canvas id="plate" width="1600" height="900" aria-label="Cosmogenesis canvas"></canvas>
+  <main>
+    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+    <p class="note">Static layers: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice. No animation, no autoplay, ND-safe palette.</p>
   </main>
-  <footer class="bar small">ND-safe • no autoplay • gentle motion only</footer>
-  <script type="module" src="./index.js"></script>
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const statusEl = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    const NUM = {
+      THREE:3,
+      SEVEN:7,
+      NINE:9,
+      ELEVEN:11,
+      TWENTYTWO:22,
+      THIRTYTHREE:33,
+      NINETYNINE:99,
+      ONEFORTYFOUR:144
+    };
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        muted:"#a6a6c1",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    function applyPalette(palette) {
+      const root = document.documentElement.style;
+      root.setProperty("--bg", palette.bg || defaults.palette.bg);
+      root.setProperty("--ink", palette.ink || defaults.palette.ink);
+      root.setProperty("--muted", palette.muted || defaults.palette.muted || "#a6a6c1");
+      if (Array.isArray(palette.layers) && palette.layers.length) {
+        const primary = palette.layers[0];
+        const halo = palette.layers[3] || palette.layers[0];
+        root.setProperty("--lattice", primary);
+        root.setProperty("--halo", halo);
+      }
+    }
+
+    async function loadPalette() {
+      try {
+        const module = await import("./data/palette.json", { assert: { type: "json" } });
+        return module.default;
+      } catch (err) {
+        try {
+          const res = await fetch("./data/palette.json", { cache: "no-store" });
+          if (!res.ok) throw new Error(String(res.status));
+          return await res.json();
+        } catch (fallbackErr) {
+          return null;
+        }
+      }
+    }
+
+    async function init() {
+      const palette = await loadPalette();
+      const active = palette || defaults.palette;
+      applyPalette(active);
+      if (palette) {
+        statusEl.textContent = "Palette loaded.";
+        statusEl.classList.remove("fallback");
+      } else {
+        statusEl.textContent = "Palette missing or blocked; using safe fallback.";
+        statusEl.classList.add("fallback");
+      }
+
+      try {
+        renderHelix(ctx, {
+          width: canvas.width,
+          height: canvas.height,
+          palette: active,
+          NUM
+        });
+      } catch (err) {
+        statusEl.textContent = `Renderer error: ${err.message}`;
+        statusEl.classList.add("fallback");
+      }
+    }
+
+    init();
+  </script>
+
+  <style>
+:root{ --lattice:#89a3ff; --halo:#d6b370; }
+.bg-lattice{position:fixed; inset:0; z-index:-1; display:grid; place-items:center; pointer-events:none}
+.lattice{
+  width:min(78vmin,880px); aspect-ratio:1; border-radius:50%; position:relative; isolation:isolate;
+  /* wireframe: meridians + parallels */
+  background:
+   repeating-conic-gradient(from 0deg, transparent 0 10deg, rgba(255,255,255,.08) 10deg 11deg),
+   repeating-radial-gradient(circle at 50% 50%, rgba(255,255,255,.08) 0 2px, transparent 2px 38px);
+  /* crisp ring */
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,.10) inset,
+    0 0 120px color-mix(in oklab, var(--lattice) 40%, transparent);
+  backdrop-filter: blur(0.5px);
+}
+.lattice::after{ /* Jovian middle ring */
+  content:""; position:absolute; inset:14%; border-radius:50%;
+  border:1px solid color-mix(in oklab, var(--halo) 75%, transparent);
+  box-shadow: 0 0 42px color-mix(in oklab, var(--halo) 30%, transparent) inset;
+  transform: perspective(700px) rotateX(62deg);
+}
+  </style>
+  <div class="bg-lattice" aria-hidden="true"><div class="lattice"></div></div>
+
+  <canvas id="nodes" width="1024" height="1024" style="position:fixed;inset:0;z-index:-1;pointer-events:none;"></canvas>
+  <script>
+    (() => {
+      const canvas = document.getElementById("nodes");
+      if (!canvas) return;
+      const context = canvas.getContext("2d");
+      // ND-safe: static glow network; redraw only on resize to avoid motion.
+      const draw = () => {
+        const size = Math.min(window.innerWidth, window.innerHeight) * 0.78;
+        const pixel = size * (window.devicePixelRatio || 1);
+        canvas.width = canvas.height = pixel;
+        canvas.style.width = canvas.style.height = size + "px";
+        canvas.style.left = ((window.innerWidth - size) / 2) + "px";
+        canvas.style.top = ((window.innerHeight - size) / 2) + "px";
+        const nodes = 72;
+        const radius = (pixel / 2) * 0.94;
+        const cx = canvas.width / 2;
+        const cy = canvas.height / 2;
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        for (let i = 0; i < nodes; i++) {
+          const angle = (i / nodes) * Math.PI * 2;
+          const x = cx + Math.cos(angle) * radius;
+          const y = cy + Math.sin(angle * 1.618) * radius * 0.65;
+          const glow = context.createRadialGradient(x, y, 0, x, y, 10 * (window.devicePixelRatio || 1));
+          glow.addColorStop(0, "#ffffff");
+          glow.addColorStop(1, "rgba(137,163,255,0.05)");
+          context.fillStyle = glow;
+          context.beginPath();
+          context.arc(x, y, 4 * (window.devicePixelRatio || 1), 0, Math.PI * 2);
+          context.fill();
+        }
+      };
+      draw();
+      window.addEventListener("resize", draw, { passive: true });
+    })();
+  </script>
+  <script>
+    window.addEventListener("cathedral:select", event => {
+      const tint = event.detail && event.detail.payload && event.detail.payload.color ? event.detail.payload.color : "#89a3ff";
+      document.documentElement.style.setProperty("--lattice", tint);
+    });
+  </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,338 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers are drawn in a fixed order to maintain gentle depth cues:
+    1) Vesica field (intersecting circles) for grounding.
+    2) Tree-of-Life scaffold (10 sephirot, 22 paths) for structural anchors.
+    3) Fibonacci curve (log spiral) for harmonic flow.
+    4) Double-helix lattice (phase-shifted strands) for cosmic weave.
+
+  All geometry uses numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to respect lore.
+  Each helper is pure: it only depends on supplied parameters and returns new data.
+*/
+
+const FALLBACK_NUM = {
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144
+};
+
+export function renderHelix(ctx, options) {
+  const dims = { width: options.width, height: options.height };
+  const palette = normalisePalette(options.palette);
+  const NUM = options.NUM || FALLBACK_NUM;
+
+  ctx.save();
+  ctx.clearRect(0, 0, dims.width, dims.height);
+
+  fillBackground(ctx, palette, dims, NUM);
+  drawVesicaLayer(ctx, dims, palette, NUM);
+  drawTreeOfLifeLayer(ctx, dims, palette, NUM);
+  drawFibonacciLayer(ctx, dims, palette, NUM);
+  drawHelixLayer(ctx, dims, palette, NUM);
+
+  ctx.restore();
+}
+
+function normalisePalette(palette) {
+  const layers = Array.isArray(palette.layers) ? palette.layers : [];
+  return {
+    bg: palette.bg || "#0b0b12",
+    ink: palette.ink || "#e8e8f0",
+    muted: palette.muted || "#a6a6c1",
+    layers,
+  };
+}
+
+function fillBackground(ctx, palette, dims, NUM) {
+  /* ND-safe: flat fill with a subtle radial glow, no motion or flicker. */
+  ctx.save();
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, dims.width, dims.height);
+  const depth = palette.layers.length || (NUM.THREE - 1);
+  const glow = ctx.createRadialGradient(
+    dims.width / (NUM.THREE - 1),
+    dims.height / depth,
+    0,
+    dims.width / (NUM.THREE - 1),
+    dims.height / (NUM.THREE - 1),
+    Math.max(dims.width, dims.height) / (NUM.THREE - 1)
+  );
+  glow.addColorStop(0, withAlpha(palette.ink, 0.06));
+  glow.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.fillStyle = glow;
+  ctx.fillRect(0, 0, dims.width, dims.height);
+  ctx.restore();
+}
+
+function drawVesicaLayer(ctx, dims, palette, NUM) {
+  /* ND-safe: concentric field only, no oscillation or animated blending. */
+  const circles = createVesicaCircles(dims, NUM);
+  ctx.save();
+  ctx.lineWidth = 1.6;
+  ctx.strokeStyle = withAlpha(pickLayer(palette.layers, 0, "#8fa1ff"), 0.44);
+  ctx.shadowColor = withAlpha(pickLayer(palette.layers, 0, "#8fa1ff"), 0.18);
+  ctx.shadowBlur = 18;
+  circles.forEach(circle => {
+    ctx.beginPath();
+    ctx.arc(circle.x, circle.y, circle.r, 0, Math.PI * 2);
+    ctx.stroke();
+  });
+  ctx.restore();
+}
+
+function createVesicaCircles(dims, NUM) {
+  const circles = [];
+  const center = { x: dims.width / 2, y: dims.height / 2 };
+  const baseRadius = Math.min(dims.width, dims.height) / (NUM.THREE + (NUM.SEVEN / NUM.ELEVEN));
+  const horizontalSpacing = baseRadius * (NUM.NINE / NUM.ELEVEN);
+  const verticalSpacing = baseRadius * (NUM.THREE / NUM.TWENTYTWO);
+
+  // Core triple vesica (3 circles)
+  for (let i = 0; i < NUM.THREE; i += 1) {
+    const offset = (i - (NUM.THREE - 1) / 2) * horizontalSpacing;
+    circles.push({ x: center.x + offset, y: center.y, r: baseRadius });
+  }
+
+  // Vertical layering using 7 bands
+  const range = Math.floor(NUM.SEVEN / 2);
+  for (let j = -range; j <= range; j += 1) {
+    const scale = (NUM.SEVEN - Math.abs(j)) / NUM.SEVEN;
+    circles.push({
+      x: center.x,
+      y: center.y + j * verticalSpacing,
+      r: baseRadius * ((NUM.NINE + scale * NUM.THREE) / NUM.TWENTYTWO)
+    });
+  }
+
+  // Diagonal overlays using 9 phases for subtle interference pattern
+  for (let k = 0; k < NUM.NINE; k += 1) {
+    const theta = (k / NUM.NINE) * Math.PI;
+    const x = center.x + Math.cos(theta) * horizontalSpacing * ((NUM.TWENTYTWO - NUM.SEVEN) / NUM.TWENTYTWO);
+    const y = center.y + Math.sin(theta) * verticalSpacing * NUM.THREE;
+    circles.push({ x, y, r: baseRadius * ((NUM.ELEVEN + NUM.THREE) / NUM.TWENTYTWO) });
+  }
+
+  return circles;
+}
+
+function drawTreeOfLifeLayer(ctx, dims, palette, NUM) {
+  /* ND-safe: thin luminous paths to avoid overwhelming contrast. */
+  const nodes = createTreeNodes(dims, NUM);
+  const paths = createTreePaths();
+  ctx.save();
+  ctx.lineWidth = 1.4;
+  ctx.lineJoin = "round";
+  ctx.strokeStyle = withAlpha(pickLayer(palette.layers, 1, "#89f7fe"), 0.36);
+  ctx.shadowColor = withAlpha(pickLayer(palette.layers, 1, "#89f7fe"), 0.18);
+  ctx.shadowBlur = 12;
+  paths.forEach(([startIndex, endIndex]) => {
+    const start = nodes[startIndex];
+    const end = nodes[endIndex];
+    ctx.beginPath();
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+  });
+  ctx.shadowBlur = 0;
+  const nodeRadius = Math.min(dims.width, dims.height) / NUM.ONEFORTYFOUR * NUM.NINE / NUM.TWENTYTWO;
+  ctx.fillStyle = withAlpha(pickLayer(palette.layers, 4, "#f5a3ff"), 0.82);
+  ctx.strokeStyle = withAlpha(palette.ink, 0.25);
+  nodes.forEach(node => {
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
+  ctx.restore();
+}
+
+function createTreeNodes(dims, NUM) {
+  const nodes = [];
+  const centerX = dims.width / 2;
+  const top = dims.height / NUM.SEVEN;
+  const verticalStep = (dims.height * (NUM.NINE / NUM.TWENTYTWO)) / NUM.NINE;
+  const horizontalOffset = dims.width / NUM.ELEVEN;
+
+  // Standard Tree-of-Life layout (10 sephirot)
+  nodes.push({ x: centerX, y: top }); // Kether
+  nodes.push({ x: centerX + horizontalOffset, y: top + verticalStep }); // Chokmah
+  nodes.push({ x: centerX - horizontalOffset, y: top + verticalStep }); // Binah
+  nodes.push({ x: centerX + horizontalOffset, y: top + verticalStep * 2 }); // Chesed
+  nodes.push({ x: centerX - horizontalOffset, y: top + verticalStep * 2 }); // Geburah
+  nodes.push({ x: centerX, y: top + verticalStep * 3 }); // Tiphereth
+  nodes.push({ x: centerX + horizontalOffset, y: top + verticalStep * 4 }); // Netzach
+  nodes.push({ x: centerX - horizontalOffset, y: top + verticalStep * 4 }); // Hod
+  nodes.push({ x: centerX, y: top + verticalStep * 5 }); // Yesod
+  nodes.push({ x: centerX, y: top + verticalStep * 6 }); // Malkuth
+
+  return nodes;
+}
+
+function createTreePaths() {
+  /* 22 paths to echo the 22 Hebrew letters while avoiding harsh diagonals. */
+  return [
+    [0, 1], [0, 2], [1, 2],
+    [1, 3], [2, 4], [3, 4],
+    [3, 5], [4, 5], [3, 6],
+    [4, 7], [5, 6], [5, 7],
+    [6, 7], [5, 8], [6, 8],
+    [7, 8], [6, 9], [7, 9],
+    [8, 9], [1, 4], [2, 3],
+    [1, 5]
+  ];
+}
+
+function drawFibonacciLayer(ctx, dims, palette, NUM) {
+  /* ND-safe: smooth polyline approximates spiral without animation. */
+  const center = { x: dims.width / 2, y: dims.height * (NUM.NINE / NUM.TWENTYTWO) };
+  const scale = Math.min(dims.width, dims.height) / NUM.ONEFORTYFOUR * NUM.ELEVEN;
+  const points = createFibonacciPoints(center, scale, NUM);
+
+  ctx.save();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = withAlpha(pickLayer(palette.layers, 3, "#ffd27f"), 0.82);
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = withAlpha(pickLayer(palette.layers, 2, "#a0ffa1"), 0.58);
+  const step = Math.max(1, Math.floor(points.length / NUM.NINE));
+  const markerRadius = Math.min(dims.width, dims.height) / NUM.ONEFORTYFOUR * (NUM.THREE / NUM.ELEVEN);
+  for (let i = 0; i < points.length; i += step) {
+    ctx.beginPath();
+    ctx.arc(points[i].x, points[i].y, markerRadius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+function createFibonacciPoints(center, scale, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const rotations = NUM.NINE / NUM.THREE; // 3 turns
+  const totalAngle = rotations * Math.PI * (NUM.TWENTYTWO / NUM.ELEVEN); // 6π
+  const growth = Math.pow(phi, rotations);
+  const b = Math.log(growth) / totalAngle;
+  const steps = NUM.THIRTYTHREE;
+  const points = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const angle = totalAngle * t;
+    const radius = scale * Math.exp(b * angle);
+    const x = center.x + radius * Math.cos(angle);
+    const y = center.y - radius * Math.sin(angle);
+    points.push({ x, y });
+  }
+  return points;
+}
+
+function drawHelixLayer(ctx, dims, palette, NUM) {
+  /* ND-safe: double helix rendered once; crossbars form static lattice. */
+  const strands = createHelixStrands(dims, NUM);
+  ctx.save();
+  ctx.lineWidth = 1.4;
+  ctx.lineJoin = "round";
+  ctx.strokeStyle = withAlpha(pickLayer(palette.layers, 5, "#d0d0e6"), 0.55);
+  drawPolyline(ctx, strands.strandA);
+  drawPolyline(ctx, strands.strandB);
+
+  ctx.strokeStyle = withAlpha(pickLayer(palette.layers, 0, "#b1c7ff"), 0.32);
+  strands.crossLinks.forEach(link => {
+    ctx.beginPath();
+    ctx.moveTo(link.a.x, link.a.y);
+    ctx.lineTo(link.b.x, link.b.y);
+    ctx.stroke();
+  });
+
+  ctx.strokeStyle = withAlpha(palette.ink, 0.18);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(dims.width / 2, dims.height / NUM.ELEVEN);
+  ctx.lineTo(dims.width / 2, dims.height - dims.height / NUM.ELEVEN);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function createHelixStrands(dims, NUM) {
+  const steps = NUM.NINETYNINE;
+  const marginY = dims.height / NUM.SEVEN;
+  const usableHeight = dims.height - marginY * 2;
+  const amplitude = Math.min(dims.width, dims.height) / NUM.THREE;
+  const centerX = dims.width / 2;
+  const rotations = NUM.NINE / NUM.THREE; // 3
+  const fullAngle = rotations * Math.PI * (NUM.TWENTYTWO / NUM.ELEVEN); // 6π
+  const strandA = [];
+  const strandB = [];
+
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const y = marginY + usableHeight * t;
+    const angle = fullAngle * t;
+    const offset = Math.sin(angle) * amplitude * (NUM.SEVEN / NUM.TWENTYTWO);
+    strandA.push({ x: centerX + offset, y });
+    strandB.push({ x: centerX - offset, y });
+  }
+
+  const crossLinks = [];
+  const crossCount = NUM.TWENTYTWO;
+  for (let j = 0; j < crossCount; j += 1) {
+    const index = Math.round((j / (crossCount - 1)) * steps);
+    crossLinks.push({ a: strandA[index], b: strandB[index] });
+  }
+
+  return { strandA, strandB, crossLinks };
+}
+
+function drawPolyline(ctx, points) {
+  if (!points.length) {
+    return;
+  }
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+}
+
+function pickLayer(layers, index, fallback) {
+  return layers && layers[index] ? layers[index] : fallback;
+}
+
+function withAlpha(hex, alpha) {
+  const rgb = hexToRgb(hex || "#ffffff");
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace("#", "");
+  if (value.length === 3) {
+    const r = parseInt(value[0] + value[0], 16);
+    const g = parseInt(value[1] + value[1], 16);
+    const b = parseInt(value[2] + value[2], 16);
+    return { r, g, b };
+  }
+  if (value.length === 6) {
+    const r = parseInt(value.slice(0, 2), 16);
+    const g = parseInt(value.slice(2, 4), 16);
+    const b = parseInt(value.slice(4, 6), 16);
+    return { r, g, b };
+  }
+  return { r: 255, g: 255, b: 255 };
+}


### PR DESCRIPTION
## Summary
- replace the root page with an offline Cosmic Helix renderer that loads a local palette fallback and draws the cathedral lattice background
- add a dedicated ES module for drawing the vesica field, Tree-of-Life scaffold, Fibonacci curve, and static helix lattice using numerology constants
- document usage and palette expectations in README_RENDERER.md while extending the palette JSON with a muted tone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccbd90274883288543879c509c7f0d