### PR TITLE
Add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,29 @@
+# Cosmic Helix Renderer
+
+This lightweight offline renderer draws four layers of sacred geometry — Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice — on a 1440×900 canvas. The palette is ND-safe: calm contrast, no motion, and every layer is annotated in code comments.
+
+## Files
+
+- `index.html` – entry point with inline status messaging and a `<canvas>` sized to 1440×900.
+- `js/helix-renderer.mjs` – pure ES module that renders the layered geometry with no external dependencies.
+- `data/palette.json` – optional palette override; edit or remove to adjust colors. Fallback colors load automatically if the file is missing or blocked by the browser.
+
+## Usage (Offline)
+
+1. Ensure the directory structure is intact (`index.html`, `js/`, `data/`).
+2. Double-click `index.html` in any modern browser. No server or build step is required.
+3. If the palette fails to load (common when using the `file://` protocol), the header status will note the fallback and the default palette will render safely.
+
+## Geometry Notes
+
+- Vesica field uses intersecting circles spaced by numerology constants (3, 7, 9) to form the foundational lattice.
+- Tree-of-Life layer plots 10 sephirot plus translucent Daath, wiring 22 static paths.
+- Fibonacci curve samples 22 steps of a logarithmic spiral using the golden ratio (φ) to keep the arc smooth without animation.
+- Double helix forms three static cycles with 22 crossbars, referencing constants 11, 22, 33, and 144 for spacing and resolution.
+
+## Customisation
+
+- Adjust palette colors inside `data/palette.json` to retint layers.
+- Geometry scale factors are expressed via the numerology constants object inside `index.html`; tweak values there or pass new ones to `renderHelix` for experiments.
+
+ND-safe oath: no animation, no flashing, no external calls. The renderer is fully offline and respects trauma-informed design.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,12 +1,12 @@
 {
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
+  "bg": "#0a0a11",
+  "ink": "#f0f0ff",
   "layers": [
-    "#b1c7ff",
-    "#89f7fe",
-    "#a0ffa1",
-    "#ffd27f",
-    "#f5a3ff",
-    "#d0d0e6"
+    "#8ba8ff",
+    "#74d8f2",
+    "#98f7c4",
+    "#ffd8a8",
+    "#f6b8ff",
+    "#d8dcff"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1,100 +1,64 @@
 <!doctype html>
-<html lang="en" data-codex="144:99" data-app="stone-grimoire">
+<html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>circuitum99 -- Cosmogenesis (Pro)</title>
-  <meta name="description" content="Cosmogenesis Learning Engine: tilted-axis cosmos, spiral nodes, and hermetic overlays. ND-safe." />
-  <link rel="stylesheet" href="./assets/css/core.css" />
-  <script type="module">
-    // single-init guard
-    import { guardInit } from './js/core/guard.js';
-    guardInit('cosmogenesis');
-
-    // theme + engine
-    import { loadStylepacks } from './js/engines/theme-engine.js';
-    import { initCosmogenesis } from './js/engines/cosmogenesis.js';
-
-    (async () => {
-      const stylepacks = await loadStylepacks('./assets/data/stylepacks.json');
-      const canvas = document.getElementById('plate');
-      const ui = {
-        tilt: document.getElementById('tilt'),
-        nodes: document.getElementById('nodes'),
-        palette: document.getElementById('palette'),
-        save: document.getElementById('save'),
-        tiltLabel: document.getElementById('tiltLabel'),
-        nodesLabel: document.getElementById('nodesLabel'),
-      };
-
-      const engine = initCosmogenesis(canvas, stylepacks);
-      // hydrate UI
-      for (const key of Object.keys(stylepacks)) {
-        const opt = document.createElement('option');
-        opt.value = key; opt.textContent = key;
-        ui.palette.appendChild(opt);
-      }
-      // restore persisted
-      const state = engine.getState();
-      ui.tilt.value = state.tilt;
-      ui.nodes.value = state.nodes;
-      ui.palette.value = state.palette;
-      ui.tiltLabel.textContent = state.tilt + '°';
-      ui.nodesLabel.textContent = state.nodes;
-
-      // wire events (gentle updates)
-      ui.tilt.addEventListener('input', e => {
-        ui.tiltLabel.textContent = e.target.value + '°';
-        engine.update({ tilt: parseFloat(e.target.value) });
-      });
-      ui.nodes.addEventListener('input', e => {
-        ui.nodesLabel.textContent = e.target.value;
-        engine.update({ nodes: parseInt(e.target.value, 10) });
-      });
-      ui.palette.addEventListener('change', e => {
-        engine.update({ palette: e.target.value });
-      });
-      ui.save.addEventListener('click', () => engine.savePNG());
-    })();
-  </script>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
 </head>
 <body>
-  <div id="nd-settings" style="padding:8px;border-bottom:1px solid #444;max-width:400px;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif">
-    <label>Motion
-      <select id="motion">
-        <option value="reduced" selected>reduced</option>
-        <option value="full">full</option>
-      </select>
-    </label>
-    <label>Autoplay
-      <input type="checkbox" id="autoplay" />
-    </label>
-    <label>Contrast
-      <select id="contrast">
-        <option value="balanced" selected>balanced</option>
-        <option value="high">high</option>
-      </select>
-    </label>
-  </div>
-  <header class="bar">
-    <h1>✦ Cosmogenesis -- Cathedral of Circuits</h1>
-    <div class="controls">
-      <label> Tilt <span id="tiltLabel"></span>
-        <input id="tilt" type="range" min="0" max="45" step="0.5" value="23.5" />
-      </label>
-      <label> Nodes <span id="nodesLabel"></span>
-        <input id="nodes" type="range" min="12" max="144" step="1" value="72" />
-      </label>
-      <label> Palette
-        <select id="palette"></select>
-      </label>
-      <button id="save" aria-label="Save PNG">Save PNG</button>
-    </div>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
-  <main class="stage">
-    <canvas id="plate" width="1600" height="900" aria-label="Cosmogenesis canvas"></canvas>
-  </main>
-  <footer class="bar small">ND-safe • no autoplay • gentle motion only</footer>
-  <script type="module" src="./index.js"></script>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants anchor geometry proportions
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,305 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers (painted bottom to top):
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; Daath rendered as translucent guide)
+    3) Fibonacci curve (log-spiral polyline)
+    4) Double-helix lattice (static intertwined strands)
+
+  ND-safe choices:
+    - No animation; everything is rendered once to avoid motion triggers.
+    - Soft contrast palette; transparent overlays maintain legibility without harsh glare.
+    - Layer order mirrors ritual staging so the eye can rest while decoding geometry.
+*/
+
+export function renderHelix(ctx, options) {
+  const config = normaliseOptions(options);
+  const { width, height, palette, NUM } = config;
+
+  ctx.save();
+  ctx.clearRect(0, 0, width, height);
+
+  paintBackground(ctx, width, height, palette, NUM);
+  drawVesicaField(ctx, width, height, palette, NUM);
+  drawTreeOfLife(ctx, width, height, palette, NUM);
+  drawFibonacciCurve(ctx, width, height, palette, NUM);
+  drawDoubleHelix(ctx, width, height, palette, NUM);
+
+  ctx.restore();
+}
+
+function normaliseOptions(options) {
+  const defaults = {
+    width: 1440,
+    height: 900,
+    palette: {
+      bg: "#0b0b12",
+      ink: "#e8e8f0",
+      layers: ["#9bbcff", "#7ee6f2", "#8ef5a5", "#ffd59b", "#f7a5ff", "#d8d8f8"]
+    },
+    NUM: { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 }
+  };
+
+  const safe = options || {};
+  const palette = safe.palette || {};
+  return {
+    width: typeof safe.width === "number" ? safe.width : defaults.width,
+    height: typeof safe.height === "number" ? safe.height : defaults.height,
+    palette: {
+      bg: palette.bg || defaults.palette.bg,
+      ink: palette.ink || defaults.palette.ink,
+      layers: Array.isArray(palette.layers) && palette.layers.length > 0 ? palette.layers : defaults.palette.layers
+    },
+    NUM: safe.NUM || defaults.NUM
+  };
+}
+
+function paintBackground(ctx, width, height, palette, NUM) {
+  ctx.save();
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  // Gentle radial glow to add depth without motion.
+  const glow = ctx.createRadialGradient(
+    width / 2,
+    height / 2,
+    Math.min(width, height) / NUM.NINETYNINE,
+    width / 2,
+    height / 2,
+    Math.max(width, height) / 2
+  );
+  glow.addColorStop(0, hexToRgba(palette.layers[1] || palette.ink, 0.12));
+  glow.addColorStop(1, hexToRgba(palette.bg, 0));
+  ctx.fillStyle = glow;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+function drawVesicaField(ctx, width, height, palette, NUM) {
+  ctx.save();
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.min(width, height) / NUM.THREE;
+  const offset = radius / (NUM.SEVEN / 2);
+  const baseColor = palette.layers[0] || palette.ink;
+
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = hexToRgba(baseColor, 0.55);
+
+  const offsets = [-1, 0, 1];
+  for (const hx of offsets) {
+    for (const hy of offsets) {
+      const x = centerX + hx * offset * 1.5;
+      const y = centerY + hy * offset * 1.2;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  // Vesica lens highlights referencing sacred ratios.
+  ctx.lineWidth = 3;
+  const lensColor = palette.layers[2] || palette.ink;
+  ctx.strokeStyle = hexToRgba(lensColor, 0.35);
+  for (let i = 0; i <= NUM.NINE; i++) {
+    const t = i / NUM.NINE;
+    const x = centerX + (t - 0.5) * radius * 1.2;
+    ctx.beginPath();
+    ctx.ellipse(centerX, centerY, radius * (0.65 + t * 0.15), radius * (0.32 + t * 0.18), 0, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function drawTreeOfLife(ctx, width, height, palette, NUM) {
+  ctx.save();
+  const nodeRadius = Math.min(width, height) / NUM.ONEFORTYFOUR * 3;
+  const colorPaths = palette.layers[3] || palette.ink;
+  const colorNodes = palette.layers[2] || palette.ink;
+  const colorHidden = palette.layers[5] || palette.ink;
+
+  const nodes = [
+    { name: "Keter", x: 0.5, y: 0.09 },
+    { name: "Chokmah", x: 0.68, y: 0.19 },
+    { name: "Binah", x: 0.32, y: 0.19 },
+    { name: "Daath", x: 0.5, y: 0.29, hidden: true },
+    { name: "Chesed", x: 0.7, y: 0.39 },
+    { name: "Geburah", x: 0.3, y: 0.39 },
+    { name: "Tiphereth", x: 0.5, y: 0.52 },
+    { name: "Netzach", x: 0.7, y: 0.64 },
+    { name: "Hod", x: 0.3, y: 0.64 },
+    { name: "Yesod", x: 0.5, y: 0.78 },
+    { name: "Malkuth", x: 0.5, y: 0.91 }
+  ];
+
+  const edges = [
+    [0,1],[0,2],[1,2],[1,4],[2,5],[4,6],[5,6],[4,3],[5,3],[3,6],
+    [4,7],[5,8],[6,7],[6,8],[7,9],[8,9],[9,10],[7,10],[8,10],[3,9],[1,3],[2,3]
+  ];
+
+  ctx.strokeStyle = hexToRgba(colorPaths, 0.45);
+  ctx.lineWidth = 2;
+  ctx.lineCap = "round";
+
+  for (const [a, b] of edges) {
+    const start = nodes[a];
+    const end = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(start.x * width, start.y * height);
+    ctx.lineTo(end.x * width, end.y * height);
+    ctx.stroke();
+  }
+
+  for (const node of nodes) {
+    const cx = node.x * width;
+    const cy = node.y * height;
+    ctx.beginPath();
+    ctx.fillStyle = node.hidden ? hexToRgba(colorHidden, 0.28) : hexToRgba(colorNodes, 0.82);
+    ctx.strokeStyle = hexToRgba(palette.ink, node.hidden ? 0.2 : 0.6);
+    ctx.lineWidth = node.hidden ? 1 : 2;
+    ctx.arc(cx, cy, node.hidden ? nodeRadius * 0.75 : nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function drawFibonacciCurve(ctx, width, height, palette, NUM) {
+  ctx.save();
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const steps = NUM.TWENTYTWO;
+  const baseRadius = Math.min(width, height) / NUM.SEVEN;
+  const centerX = width * 0.32;
+  const centerY = height * 0.58;
+  const curveColor = palette.layers[4] || palette.ink;
+
+  const points = [];
+  for (let i = 0; i <= steps; i++) {
+    const angle = -Math.PI / 2 + (Math.PI / NUM.ELEVEN) * i;
+    const radius = baseRadius * Math.pow(phi, i / NUM.NINE);
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
+    points.push({ x, y });
+  }
+
+  ctx.beginPath();
+  points.forEach((p, index) => {
+    if (index === 0) {
+      ctx.moveTo(p.x, p.y);
+    } else {
+      ctx.lineTo(p.x, p.y);
+    }
+  });
+  ctx.strokeStyle = hexToRgba(curveColor, 0.75);
+  ctx.lineWidth = 3;
+  ctx.stroke();
+
+  // Place gentle markers at numerically significant steps for clarity.
+  ctx.fillStyle = hexToRgba(curveColor, 0.6);
+  const markerSpacing = Math.max(1, Math.floor(steps / NUM.SEVEN));
+  for (let i = 0; i < points.length; i += markerSpacing) {
+    const p = points[i];
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+function drawDoubleHelix(ctx, width, height, palette, NUM) {
+  ctx.save();
+  const strandA = palette.layers[5] || palette.ink;
+  const strandB = palette.layers[1] || palette.ink;
+  const axisX = width * 0.62;
+  const top = height * 0.08;
+  const bottom = height * 0.92;
+  const amplitude = width / NUM.NINE;
+  const cycles = NUM.THREE;
+  const totalLength = bottom - top;
+  const steps = NUM.ONEFORTYFOUR;
+
+  ctx.lineWidth = 2.4;
+  ctx.lineCap = "round";
+
+  // Strand A
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const angle = t * Math.PI * 2 * cycles;
+    const x = axisX + Math.sin(angle) * amplitude;
+    const y = top + t * totalLength;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.strokeStyle = hexToRgba(strandA, 0.8);
+  ctx.stroke();
+
+  // Strand B (phase-shifted by PI to weave with strand A)
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const angle = t * Math.PI * 2 * cycles + Math.PI;
+    const x = axisX + Math.sin(angle) * amplitude;
+    const y = top + t * totalLength;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.strokeStyle = hexToRgba(strandB, 0.65);
+  ctx.stroke();
+
+  // Lattice rungs referencing the 22 paths.
+  const rungCount = NUM.TWENTYTWO;
+  ctx.strokeStyle = hexToRgba(palette.layers[3] || palette.ink, 0.3);
+  ctx.lineWidth = 1.5;
+  for (let i = 0; i <= rungCount; i++) {
+    const t = i / rungCount;
+    const angle = t * Math.PI * 2 * cycles;
+    const y = top + t * totalLength;
+    const x1 = axisX + Math.sin(angle) * amplitude;
+    const x2 = axisX + Math.sin(angle + Math.PI) * amplitude;
+    ctx.beginPath();
+    ctx.moveTo(x1, y);
+    ctx.lineTo(x2, y);
+    ctx.stroke();
+  }
+
+  // Central axis for grounding.
+  ctx.strokeStyle = hexToRgba(palette.ink, 0.22);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(axisX, top);
+  ctx.lineTo(axisX, bottom);
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function hexToRgba(hex, alpha) {
+  if (!hex) {
+    return `rgba(0,0,0,${alpha})`;
+  }
+  let value = hex.trim();
+  if (value.startsWith("#")) {
+    value = value.slice(1);
+  }
+  if (value.length === 3) {
+    value = value.split("").map((c) => c + c).join("");
+  }
+  const int = parseInt(value, 16);
+  const r = (int >> 16) & 255;
+  const g = (int >> 8) & 255;
+  const b = int & 255;
+  const clamped = Math.max(0, Math.min(1, alpha));
+  return `rgba(${r},${g},${b},${clamped})`;
+}


### PR DESCRIPTION
## Summary
- replace the root `index.html` with an offline ND-safe canvas shell that loads the helix renderer module
- add `js/helix-renderer.mjs` to draw the vesica grid, Tree-of-Life, Fibonacci curve, and static double helix lattice
- supply `data/palette.json` and `README_RENDERER.md` so the renderer has a local palette and usage notes

## Testing
- not run (static HTML renderer)


------
https://chatgpt.com/codex/tasks/task_e_68ccbc9e4d348328ad75b571b5cbc589