### PR TITLE
Add vesica chapel palettes and layout

### DIFF
--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -196,6 +196,109 @@ main {
   color: var(--ink-muted);
 }
 
+#node-list {
+  display: grid;
+  gap: 2.5rem;
+  margin-top: 2.5rem;
+}
+
+.chapel {
+  padding: clamp(2rem, 3vw, 3rem);
+  border-radius: 2.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.chapel header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.chapel header h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.chapel-type {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.chapel .lore {
+  margin: 0;
+  color: var(--ink-muted);
+  max-width: 60ch;
+}
+
+.chapel-listing {
+  display: grid;
+  gap: 0.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.chapel-label {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.chapel-items {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chapel-items li {
+  color: var(--ink-muted);
+}
+
+.chapel-protocol {
+  margin: 0;
+  font-style: italic;
+  color: var(--ink-muted);
+  max-width: 55ch;
+}
+
+.chapel-fallback {
+  margin: 0;
+  color: var(--ink-muted);
+  max-width: 60ch;
+}
+
+.open-lab {
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  cursor: pointer;
+  align-self: flex-start;
+  position: relative;
+  z-index: 1;
+}
+
+.open-lab:hover,
+.open-lab:focus {
+  background: rgba(143, 155, 255, 0.18);
+}
+
 .maison-footer {
   padding: 2rem 2.5rem 3rem;
   border-top: 1px solid var(--border);

--- a/site/assets/css/colors.css
+++ b/site/assets/css/colors.css
@@ -1,0 +1,49 @@
+:root{
+  /* your base covenant palette (keep as-is, extend gently) */
+  --obsidian:#0a0a0f; --noir: #000; --gold:#D4AF37; --violet:#6B3AA0; --teal:#50C878; --silver:#C0C0C0;
+}
+
+/* universal: when Calm Mode / reduced motion is active */
+.reduced-motion *{animation:none!important;transition:none!important}
+
+/* vesica background (two luminous ellipses crossing) */
+.vesica-bg{
+  position:relative; isolation:isolate; background:radial-gradient(120% 80% at 30% 50%, rgba(255,255,255,.06), transparent 60%),
+                                     radial-gradient(120% 80% at 70% 50%, rgba(255,255,255,.06), transparent 60%),
+                                     linear-gradient(180deg, #0a0a0f 0%, #0c0c14 100%);
+}
+.vesica-bg::before,
+.vesica-bg::after{
+  content:""; position:absolute; inset:-20vh -10vw;
+  background:radial-gradient(55% 40% at 35% 50%, var(--vesica-a, #ffffff0a), transparent 70%);
+  mix-blend-mode: screen; opacity:.7; filter: blur(12px);
+}
+.vesica-bg::after{
+  background:radial-gradient(55% 40% at 65% 50%, var(--vesica-b, #ffffff08), transparent 70%);
+}
+
+/* tarot overlay: ultra subtle color wash pulled from path palette */
+.tarot-overlay{
+  position:relative; isolation:isolate;
+}
+.tarot-overlay::after{
+  content:""; position:absolute; inset:0;
+  background: radial-gradient(120% 90% at 50% 60%,
+              color-mix(in oklab, var(--path-primary, #fff) 18%, transparent),
+              transparent 70%),
+              radial-gradient(100% 60% at 50% 20%,
+              color-mix(in oklab, var(--path-secondary, #fff) 10%, transparent),
+              transparent 70%);
+  pointer-events:none; mix-blend-mode: screen;
+}
+
+/* optional aurora shimmer (auto-disabled by reduced-motion) */
+@keyframes auroraFloat{ 0%{transform:translateY(0)} 50%{transform:translateY(-1.2rem)} 100%{transform:translateY(0)} }
+.aurora{
+  position:relative;
+}
+.aurora::before{
+  content:""; position:absolute; inset:-10% -10%;
+  background: radial-gradient(120% 120% at 50% 50%, #ffffff06, transparent 60%);
+  animation: auroraFloat 12s ease-in-out infinite;
+}

--- a/site/assets/js/nodes.js
+++ b/site/assets/js/nodes.js
@@ -1,50 +1,164 @@
-// nodes.js — offline-first loader for node registry
-const grid = document.getElementById('nodeGrid');
-const source = '../data/nodes.json';
+// nodes.js — paints chapels with thelemic path palettes and hydrates node data
+import paths from '../../palettes/thelemic_letters.json' assert { type: 'json' };
 
-/**
- * Create the HTML markup for a node card.
- * Small pure function keeps rendering predictable and readable.
- */
-function renderCard(node) {
-  return `
-    <article class="card" role="listitem">
-      <h3>${node.title}</h3>
-      <p>${node.summary}</p>
-    </article>
-  `;
+const registry = Array.isArray(paths?.paths) ? paths.paths : [];
+const pathIndex = new Map();
+for (const entry of registry) {
+  if (entry?.letter && !pathIndex.has(entry.letter)) pathIndex.set(entry.letter, entry);
+  if (entry?.thelemicPath && !pathIndex.has(entry.thelemicPath)) pathIndex.set(entry.thelemicPath, entry);
+  if (entry?.id && !pathIndex.has(entry.id)) pathIndex.set(entry.id, entry);
 }
 
-/**
- * Render a friendly fallback message when data is unavailable.
- */
-function renderFallback(message) {
-  grid.innerHTML = `
-    <article class="card" role="listitem">
-      <h3>Node registry offline</h3>
-      <p>${message}</p>
-    </article>
-  `;
-}
-
-async function loadNodes() {
-  if (!grid) return;
-  try {
-    const response = await fetch(source, { cache: 'no-store' });
-    if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`);
-    }
-    const payload = await response.json();
-    const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
-    if (!nodes.length) {
-      renderFallback('No nodes registered yet. Calm archives will populate soon.');
-      return;
-    }
-    grid.innerHTML = nodes.map(renderCard).join('');
-  } catch (error) {
-    console.warn('Node registry could not load.', error);
-    renderFallback('Local data missing. Check data/nodes.json for updates.');
+function tintValue(base, fallback) {
+  if (typeof base === 'string' && base.startsWith('#') && base.length === 7) {
+    return `${base}20`;
   }
+  return fallback;
 }
 
-loadNodes();
+/** call after you render a “chapel” element */
+export function paintChapel(el, thelemicPath) {
+  if (!el) return;
+  const key = typeof thelemicPath === 'string' ? thelemicPath : '';
+  const normalized = key.trim();
+  const p = pathIndex.get(normalized) || pathIndex.get(normalized.toUpperCase());
+  if (!p) return;
+  if (p.primary) el.style.setProperty('--path-primary', p.primary);
+  if (p.secondary) el.style.setProperty('--path-secondary', p.secondary);
+  const accents = Array.isArray(p.accents) ? p.accents : [];
+  el.style.setProperty('--vesica-a', accents[0] || tintValue(p.primary, '#ffffff12'));
+  el.style.setProperty('--vesica-b', accents[1] || tintValue(p.secondary, '#ffffff10'));
+  el.classList.add('vesica-bg', 'tarot-overlay', 'aurora');
+}
+
+function normalizeList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter((item) => typeof item === 'string' && item.trim().length);
+  if (typeof value === 'string') return value.trim().length ? [value.trim()] : [];
+  return [];
+}
+
+function renderList(label, items) {
+  const list = normalizeList(items);
+  if (!list.length) return null;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'chapel-listing';
+  const heading = document.createElement('p');
+  heading.className = 'chapel-label';
+  heading.textContent = label;
+  wrapper.appendChild(heading);
+  const ul = document.createElement('ul');
+  ul.className = 'chapel-items';
+  for (const item of list) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    ul.appendChild(li);
+  }
+  wrapper.appendChild(ul);
+  return wrapper;
+}
+
+function renderFallback(root, message) {
+  root.innerHTML = '';
+  const p = document.createElement('p');
+  p.className = 'chapel-fallback';
+  p.textContent = message;
+  root.appendChild(p);
+}
+
+function renderNode(node) {
+  const card = document.createElement('section');
+  card.className = 'chapel';
+  if (node.thelemicPath) {
+    card.setAttribute('data-path', node.thelemicPath);
+  }
+
+  const header = document.createElement('header');
+  const title = document.createElement('h2');
+  title.textContent = node.name || node.title || node.id || 'Unnamed Chapel';
+  header.appendChild(title);
+
+  if (node.type) {
+    const tag = document.createElement('p');
+    tag.className = 'chapel-type';
+    tag.textContent = node.type;
+    header.appendChild(tag);
+  }
+
+  card.appendChild(header);
+
+  const loreText = node.lore || node.summary;
+  if (loreText) {
+    const lore = document.createElement('p');
+    lore.className = 'lore';
+    lore.textContent = loreText;
+    card.appendChild(lore);
+  }
+
+  const curriculum = renderList('Curriculum', node.curriculum);
+  if (curriculum) card.appendChild(curriculum);
+
+  if (node.labProtocol) {
+    const protocol = document.createElement('p');
+    protocol.className = 'chapel-protocol';
+    protocol.textContent = node.labProtocol;
+    card.appendChild(protocol);
+  }
+
+  const assets = renderList('Assets', node.assets);
+  if (assets) card.appendChild(assets);
+
+  if (node.lab) {
+    const button = document.createElement('button');
+    button.className = 'open-lab';
+    button.type = 'button';
+    button.setAttribute('data-lab', node.lab);
+    button.textContent = 'Enter Lab';
+    card.appendChild(button);
+  }
+
+  paintChapel(card, node.thelemicPath);
+  return card;
+}
+
+/* sample progressive enhancement hookup */
+export async function hydrateNodes() {
+  const root = document.getElementById('node-list');
+  if (!root) return;
+  let nodes = [];
+  try {
+    const r = await fetch('data/nodes.json', { cache: 'no-store' });
+    const payload = await r.json();
+    nodes = Array.isArray(payload) ? payload : [];
+  } catch {
+    renderFallback(root, 'Local node data could not be reached. Offline chapel notes remain available in the Codex.');
+    return;
+  }
+
+  if (!nodes.length) {
+    renderFallback(root, 'No chapels registered yet. Add entries to data/nodes.json to manifest them.');
+    return;
+  }
+
+  root.innerHTML = '';
+  for (const node of nodes) {
+    const chapel = renderNode(node);
+    root.appendChild(chapel);
+  }
+
+  root.addEventListener('click', (e) => {
+    const b = e.target.closest('.open-lab');
+    if (!b) return;
+    const href = b.getAttribute('data-lab') || '';
+    try {
+      const u = new URL(href, window.location.origin);
+      if (u.origin !== window.location.origin) return;
+      const w = window.open(u.href, '_blank', 'noopener,noreferrer');
+      if (w) w.opener = null;
+    } catch {
+      // noop — invalid URLs are ignored for safety
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', hydrateNodes);

--- a/site/data/nodes.json
+++ b/site/data/nodes.json
@@ -1,16 +1,80 @@
-{
-  "nodes": [
-    {
-      "title": "Node 03 - Harmonic Crucible",
-      "summary": "Triadic resonance field exploring vesica alignments and calm chromatics for studio rituals."
-    },
-    {
-      "title": "Node 09 - Choir of Circuits",
-      "summary": "Choral study of tarot correspondences mapped to circuit sigils with printable overlays."
-    },
-    {
-      "title": "Node 22 - Spiral Archive",
-      "summary": "Offline-first library of Fibonacci spirals, double-helix notes, and workshop prompts."
-    }
-  ]
-}
+[
+  {
+    "id": "00-void",
+    "name": "Void Chapel",
+    "type": "Chapel",
+    "thelemicPath": "Aleph",
+    "lore": "Vesica cradle for first breath; initiates calm modulation before any circuitry ignites.",
+    "summary": "Triadic zero-point anchoring breath practice and sensing rituals.",
+    "curriculum": [
+      "Breathwork triptych — inhale, hold, release (3 beats)",
+      "Sevenfold sensory check-in for ND-safe grounding",
+      "Nine-sigil tracing to map calm pathways"
+    ],
+    "labProtocol": "Follow the calm toggle before any helix overlays; respect reduced-motion requests first.",
+    "assets": [
+      "pdf/void-chapel-manual.pdf",
+      "audio/void-temple-tone.avif",
+      "notes/void-field-notebook.md"
+    ],
+    "lab": "labs/void-lab.html"
+  },
+  {
+    "id": "03-crucible",
+    "name": "Harmonic Crucible",
+    "type": "Chapel",
+    "thelemicPath": "Gimel",
+    "lore": "Triadic resonance field exploring vesica alignments and calm chromatics for studio rituals.",
+    "summary": "Triadic resonance field exploring vesica alignments and calm chromatics for studio rituals.",
+    "curriculum": [
+      "Three-tone harmonic ladder drills",
+      "Seven spiral sketches mapping vesica crossings",
+      "Eleven-minute journaling on choir resonance"
+    ],
+    "labProtocol": "Mix pigments at 33% opacity before layering; keep gradients soft within a 10% luminance delta.",
+    "assets": [
+      "sketches/harmonic-crucible-grid.png",
+      "pdf/harmonic-crucible-folio.pdf"
+    ],
+    "lab": ""
+  },
+  {
+    "id": "09-choir",
+    "name": "Choir of Circuits",
+    "type": "Chapel",
+    "thelemicPath": "Teth",
+    "lore": "Choral study of tarot correspondences mapped to circuit sigils with printable overlays.",
+    "summary": "Choral study of tarot correspondences mapped to circuit sigils with printable overlays.",
+    "curriculum": [
+      "Nine-voice resonance braid for ND vocal pacing",
+      "Twenty-two card correspondences cross-index",
+      "Ninety-nine beat metronome pattern for calm cadence"
+    ],
+    "labProtocol": "Use spiral metronome under 60 BPM and mute any bright leds; overlay prints only after contrast audit.",
+    "assets": [
+      "pdf/choir-of-circuits-sheet.pdf",
+      "charts/arcanae-correspondence.csv"
+    ],
+    "lab": ""
+  },
+  {
+    "id": "22-spiral",
+    "name": "Spiral Archive",
+    "type": "Chapel",
+    "thelemicPath": "Tav",
+    "lore": "Offline-first library of Fibonacci spirals, double-helix notes, and workshop prompts.",
+    "summary": "Offline-first library of Fibonacci spirals, double-helix notes, and workshop prompts.",
+    "curriculum": [
+      "Eleven spiral diagram meditations",
+      "Thirty-three helix lattice case studies",
+      "One-hundred-forty-four step archive review"
+    ],
+    "labProtocol": "Catalog updates offline, then sync to Codex manually; never break the calm lighting matrix.",
+    "assets": [
+      "spreads/spiral-archive-blueprint.tif",
+      "notes/spiral-archive-ledger.md",
+      "models/double-helix-static.obj"
+    ],
+    "lab": ""
+  }
+]

--- a/site/index.html
+++ b/site/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="A living grimoire: sacred geometry, techno-occult research, and spiral learning." />
   <link rel="preload" href="assets/img/hero.avif" as="image" />
   <link rel="stylesheet" href="assets/css/atelier.css" />
+  <link rel="stylesheet" href="assets/css/colors.css" />
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -21,7 +22,7 @@
     <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
   </nav>
 
-  <main id="main">
+  <main id="main" class="vesica-bg tarot-overlay aurora">
     <section class="hero" aria-labelledby="hero-title">
       <figure class="hero-visual">
         <img src="assets/img/hero.avif" width="1280" height="720" alt="Layered circuit sigil with calm indigo gradient." />
@@ -74,7 +75,9 @@
     <section class="section" id="node-system" aria-labelledby="node-title">
       <h2 id="node-title">Node System</h2>
       <p>The node registry keeps track of living research threads. Data loads locally from <code>data/nodes.json</code> so the atlas stays offline-first.</p>
-      <div id="nodeGrid" class="grid" role="list" aria-live="polite"></div>
+      <section id="node-list" aria-label="Cosmogenesis Chapels" aria-live="polite">
+        <p class="chapel-fallback">Chapels manifest once local data loads. Offline? The Codex still holds their coordinates.</p>
+      </section>
     </section>
 
     <section class="section" id="atelier" aria-labelledby="atelier-title">

--- a/site/palettes/thelemic_letters.json
+++ b/site/palettes/thelemic_letters.json
@@ -1,0 +1,69 @@
+{
+  "paths": [
+    {
+      "id": "00-void",
+      "name": "Void",
+      "type": "Chapel",
+      "letter": "Aleph",
+      "thelemicPath": "Aleph",
+      "blend": "vesica-aurora",
+      "lore": "The silent organ of genesis; breath before word.",
+      "lab": "labs/void-lab.html",
+      "primary": "#89b4ff",
+      "secondary": "#b8f0ff",
+      "accents": ["#6B3AA0", "#50C878"]
+    },
+    {
+      "id": "01-magician",
+      "name": "The Magus",
+      "type": "Chapel",
+      "letter": "Beth",
+      "thelemicPath": "Beth",
+      "blend": "vesica-aurora",
+      "lore": "Mercurial hand weaving circuits & spirit.",
+      "lab": "labs/magus-lab.html",
+      "primary": "#f5c16c",
+      "secondary": "#f2a7ff",
+      "accents": ["#D4AF37", "#C0C0C0"]
+    },
+    {
+      "id": "03-crucible",
+      "name": "Harmonic Crucible",
+      "type": "Chapel",
+      "letter": "Gimel",
+      "thelemicPath": "Gimel",
+      "blend": "vesica-harmonics",
+      "lore": "Triadic resonance chamber linking vesica streams to choir circuits.",
+      "lab": "",
+      "primary": "#c0b7ff",
+      "secondary": "#89f7fe",
+      "accents": ["#ffd27f", "#b0ffe1"]
+    },
+    {
+      "id": "09-choir",
+      "name": "Choir of Circuits",
+      "type": "Chapel",
+      "letter": "Teth",
+      "thelemicPath": "Teth",
+      "blend": "vesica-choir",
+      "lore": "Circuitous choir weaving strength through harmonic breath.",
+      "lab": "",
+      "primary": "#ffb38a",
+      "secondary": "#ffe5a8",
+      "accents": ["#f5a3ff", "#89f7fe"]
+    },
+    {
+      "id": "22-spiral",
+      "name": "Spiral Archive",
+      "type": "Chapel",
+      "letter": "Tav",
+      "thelemicPath": "Tav",
+      "blend": "vesica-archive",
+      "lore": "Archive of spiral memory; quiet circuits closing the loop.",
+      "lab": "",
+      "primary": "#cbd0ff",
+      "secondary": "#9adfff",
+      "accents": ["#ffd27f", "#6B3AA0"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a thelemic path palette dataset and vesica background utilities for chapel overlays
- rebuild the node hydrator to paint chapels with palette variables and render curriculum metadata
- reshape the homepage node chamber to use the new vesica nave styling

## Testing
- npm test *(fails: SyntaxError: Unexpected token 'export' in engines/interface-guard.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cccef820208328b04b166d60d8b2dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic “Chapel” cards with richer details (lore, curriculum, assets) and lab launch buttons.
  - Automatic theming per path with palette-driven colors.
  - Improved offline handling with clear fallback messages.

- Style
  - New color palette and visual accents: vesica background, tarot overlay, and optional aurora shimmer.
  - Refined grid layout for the node list and a polished chapel card design.

- Accessibility
  - Respects reduced-motion preferences (disables animations accordingly).
  - Improved semantics and live updates for the chapels list.
  - Enhanced focus and hover states for interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->