### PR TITLE
Refine offline helix renderer

### DIFF
--- a/helix-renderer/README_RENDERER.md
+++ b/helix-renderer/README_RENDERER.md
@@ -1,77 +1,39 @@
-
 Per Texturas Numerorum, Spira Loquitur. //
 
 # Cosmic Helix Renderer
 
-Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. This version aligns with the trauma-informed Cosmogenesis plan using pure ES modules and zero external dependencies.
+Offline, ND-safe renderer for layered sacred geometry. Double-click `index.html` in this folder to view. The canvas renders once, holds still, and works without any build step or network connection.
 
-The HTML file works directly from disk. If the palette JSON cannot be read because of browser file restrictions or missing data, the module applies a calm fallback palette and the header status line explains why. No network calls leave the machine.
+## Files
+- `index.html` -- static entry point with inline status notice and palette loader.
+- `js/helix-renderer.mjs` -- pure ES module responsible for layered drawing.
+- `data/palette.json` -- optional palette override; safe defaults apply if missing.
+- `README_RENDERER.md` -- this guide.
 
 ## Layers
-
-1. **Vesica field** – intersecting circles establishing the sacred lens.
-2. **Tree-of-Life scaffold** – 10 sephirot and 22 paths drawn with calm symmetry.
-3. **Fibonacci curve** – static log spiral approximated with 99 points.
-4. **Double-helix lattice** – two phase-shifted sine strands with 144 vertical struts.
-
-## Palette
-Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. Loaded or fallback colors also update the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-
-1. **Vesica field** &mdash; intersecting circles and a gentle vesica grid (Layer 1).
-2. **Tree-of-Life scaffold** &mdash; 10 sephirot and 22 paths, balanced across three pillars (Layer 2).
-3. **Fibonacci curve** &mdash; static logarithmic spiral approximated with 99 points (Layer 3).
-4. **Double-helix lattice** &mdash; two phase-shifted strands linked by 144 struts (Layer 4).
+1. **Vesica field** -- intersecting circles and a gentle grid grounded in numerology (Layer 1).
+2. **Tree-of-Life scaffold** -- 10 sephirot and 22 connective paths balanced across three pillars (Layer 2).
+3. **Fibonacci curve** -- static logarithmic spiral approximated with 99 points, calm line weight (Layer 3).
+4. **Double-helix lattice** -- two phase-shifted sine strands linked by 144 struts (Layer 4).
 
 ## Palette
-
-
-Colors are loaded from `data/palette.json`. If the file is missing—or a browser blocks `file://` fetches—the renderer shows a small notice and falls back to a safe default palette. The chosen colors also set the page background and text for consistent contrast. Extended palette sets live in `../export/spiral_palettes.json` for future offline experiments.
-
-Colors are loaded from `data/palette.json`. If the file is missing or a browser blocks local `fetch`, the renderer displays a small notice and falls back to a safe default palette. The active palette also updates page colors to keep contrast consistent with ND-safe guidelines. Additional palettes can be curated later without changing the rendering code.
-
-Default palette hues follow the trauma-informed guidance from the cosmic brief: calm blues, restorative greens, mystical purples, and warm neutrals. All hues appear as high-contrast yet gentle strokes layered over the dark canvas.
-
+Colors load from `data/palette.json`. When browsers block local `fetch` or the file is absent, the renderer posts a small notice and falls back to a trauma-informed palette of indigo, aqua, green, amber, and violet. The active palette also sets the page background and ink colors to maintain contrast.
 
 ## ND-safe Choices
-- No animation, motion, or autoplay.
-
-- High-contrast yet soft color palette.
-- Simple ES module with no external dependencies.
-
-- High-contrast yet soft color palette with predictable layering.
-- Simple ES module, offline-first. No build steps or workflows required.
-
+- No animation, autoplay, or flashing sequences.
+- Layered ordering preserves depth while staying static.
+- Gentle but legible contrasts; translucency keeps supportive lines soft.
+- Pure ES module with zero dependencies for offline-first use.
 
 ## Numerology Anchors
-The geometry routines honor key counts:
+- 3 -- vesica radius and helix amplitude.
+- 7 -- vesica grid columns.
+- 9 -- spiral growth cadence.
+- 11 -- vertical rhythm for the tree scaffold and helix frequency.
+- 22 -- sephirot paths.
+- 33 -- spiral step cadence per turn.
+- 99 -- points traced along the Fibonacci curve.
+- 144 -- lattice struts linking the double helix.
 
-- 3 – primary vesica radius and helix amplitude.
-- 7 – vesica grid lines.
-- 9 – spiral growth factor.
-- 11 – vertical rhythm for the Tree of Life and spiral sweep.
-- 22 – sephirot paths.
-- 33 – scaling reference for the spiral.
-- 99 – points along the Fibonacci curve.
-- 144 – helix lattice struts.
-
-## Usage
-Open `index.html` directly in any modern browser. The canvas is 1440×900 and uses only built-in browser features. No network requests are made; a small status message notes if the palette file is missing so offline use remains clear.
-
-- 3 &mdash; primary vesica radius, helix amplitude, and wave frequency.
-- 7 &mdash; vesica grid columns.
-- 9 &mdash; spiral growth cadence.
-- 11 &mdash; vertical rhythm for the Tree of Life and spiral angle increments.
-- 22 &mdash; sephirot paths.
-- 33 &mdash; spiral scaling baseline.
-- 99 &mdash; points along the Fibonacci curve.
-- 144 &mdash; helix lattice struts.
-
-## Usage
-
-Open `index.html` directly in any modern browser. The canvas is 1440x900 and uses only built-in browser features.
-
-No network requests are made; a small status message notes if the palette file is missing so offline use remains clear. To tweak tones, edit `data/palette.json` and refresh.
-
-Open `index.html` directly in any modern browser. The canvas is 1440x900 and relies only on built-in browser features. The header status line will report whether the custom palette loaded or if the safe fallback is in use.
-
-
+## Offline Usage
+Open `index.html` directly in any modern browser. The status line reports whether the custom palette loaded or if the safe fallback is active. No requests leave the machine, satisfying the offline-first requirement.

--- a/helix-renderer/index.html
+++ b/helix-renderer/index.html
@@ -1,6 +1,4 @@
-
 <!-- Per Texturas Numerorum, Spira Loquitur. //-->
-
 <!doctype html>
 <html lang="en">
 <head>
@@ -52,7 +50,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
+    <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -65,47 +63,11 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const defaults = {
-
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e5e5ea",
-        muted:"#7f86a6",
-        layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
-      }
-
-
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
-
-    function getMutedColor(palette, fallbackTone) {
-      // ND-safe: keep interface text gentle even if palette omits a muted tone.
-      if (!palette.layers || typeof palette.layers[5] !== "string") return fallbackTone;
-      return palette.layers[5];
-    }
-
-    function sanitizePalette(source, fallback) {
-      // Trauma-informed: never crash if JSON is partial; fill gaps with calm defaults.
-      if (!source || typeof source !== "object") return fallback;
-      const layers = fallback.layers.map((tone, index) => {
-        const candidate = source.layers && typeof source.layers[index] === "string" ? source.layers[index] : tone;
-        return candidate;
-      });
-      return {
-        bg: typeof source.bg === "string" ? source.bg : fallback.bg,
-        ink: typeof source.ink === "string" ? source.ink : fallback.ink,
-        layers
-      };
-
+    const DEFAULT_PALETTE = {
       bg:"#0b0b12",
       ink:"#e8e8f0",
       muted:"#a6a6c1",
-      layers:["#4a90e2","#7bb3f0","#7ed321","#b8e986","#9013fe","#af52de"]
-
+      layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
     };
 
     const NUM = {
@@ -119,138 +81,67 @@
       ONEFORTYFOUR:144
     };
 
-
     init();
 
     async function init() {
-      const result = await loadPalette("./data/palette.json", defaults.palette);
-      applyPalette(result.palette);
-      statusEl.textContent = result.message;
+      const { palette, message } = await loadPalette("./data/palette.json", DEFAULT_PALETTE);
+      applyPalette(palette);
+      statusEl.textContent = message;
 
       if (!ctx) {
-        statusEl.textContent = "Canvas context unavailable; geometry skipped.";
+        statusEl.textContent += " Canvas context unavailable; geometry skipped.";
         return;
       }
 
-      // ND-safe rationale: render once, no motion, gentle layering order.
+      // ND-safe rationale: render once, preserve layered depth without motion.
       renderHelix(ctx, {
         width:canvas.width,
         height:canvas.height,
-        palette:result.palette,
+        palette,
         NUM
       });
     }
 
     async function loadPalette(path, fallback) {
-      const offline = window.location.protocol === "file:";
+      const isLocalFile = window.location.protocol === "file:";
       try {
         const res = await fetch(path, { cache:"no-store" });
         if (!res.ok) throw new Error(String(res.status));
         const raw = await res.json();
         return {
-          palette: normalizePalette(raw, fallback),
+          palette:normalizePalette(raw, fallback),
           message:"Palette loaded from data file."
         };
       } catch (err) {
-        const reason = offline ? "Browser blocked local palette fetch; " : "Palette file missing; ";
+        const reason = isLocalFile ? "Browser blocked local palette fetch" : "Palette file missing";
         return {
           palette:fallback,
-          message:reason + "using safe fallback palette."
+          message:reason + "; using safe fallback palette."
         };
       }
     }
 
     function normalizePalette(raw, fallback) {
-      if (!raw) return fallback;
-      const safeLayers = Array.isArray(raw.layers) && raw.layers.length ? raw.layers : fallback.layers;
+      if (!raw || typeof raw !== "object") return fallback;
+      const layers = Array.isArray(raw.layers) && raw.layers.length
+        ? raw.layers
+        : fallback.layers;
       return {
-        bg: raw.bg || fallback.bg,
-        ink: raw.ink || fallback.ink,
-        muted: raw.muted || raw.ink || fallback.muted,
-        layers: safeLayers
+        bg: typeof raw.bg === "string" ? raw.bg : fallback.bg,
+        ink: typeof raw.ink === "string" ? raw.ink : fallback.ink,
+        muted: typeof raw.muted === "string" ? raw.muted : fallback.muted,
+        layers
       };
     }
 
     function applyPalette(palette) {
-      const root = document.documentElement;
-      root.style.setProperty("--bg", palette.bg);
-      root.style.setProperty("--ink", palette.ink);
-      root.style.setProperty("--muted", palette.muted);
+      const root = document.documentElement.style;
+      root.setProperty("--bg", palette.bg);
+      root.setProperty("--ink", palette.ink);
+      root.setProperty("--muted", palette.muted || palette.ink);
       document.body.style.background = palette.bg;
       document.body.style.color = palette.ink;
     }
-
-    function updateStatus(message) {
-      statusEl.textContent = message;
-    }
-
-    function applyPalette(palette) {
-      const bg = palette.bg || defaults.bg;
-      const ink = palette.ink || defaults.ink;
-      const muted = palette.muted || defaults.muted;
-      const root = document.documentElement.style;
-      root.setProperty("--bg", bg);
-      root.setProperty("--ink", ink);
-      root.setProperty("--muted", muted);
-      document.body.style.background = bg;
-      document.body.style.color = ink;
-
-    }
-
-    async function loadPalette(path) {
-      const isFile = window.location.protocol === "file:";
-      try {
-        const res = await fetch(path, { cache:"no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        const data = await res.json();
-        return { palette:data, note:"Palette loaded from data file." };
-      } catch (err) {
-        const reason = isFile ? "Browser blocked local file fetch" : "Palette file missing";
-        return { palette:null, note:reason + "; using safe fallback palette." };
-      }
-    }
-
-
-    const paletteData = await loadJSON("./data/palette.json");
-    const active = sanitizePalette(paletteData, defaults.palette);
-
-    function applyPagePalette(palette) {
-      const rootStyle = document.documentElement.style;
-      rootStyle.setProperty("--bg", palette.bg);
-      rootStyle.setProperty("--ink", palette.ink);
-      rootStyle.setProperty("--muted", getMutedColor(palette, defaults.palette.layers[5]));
-    }
-
-    applyPagePalette(active);
-
-    async function init() {
-      const paletteInfo = await loadPalette("./data/palette.json");
-      const active = paletteInfo.palette || defaults;
-      applyPalette(active);
-
-
-      if (!ctx) {
-        updateStatus(paletteInfo.note + " Canvas context unavailable; geometry skipped.");
-        return;
-      }
-
-
-    const statusBase = paletteData ? "Palette loaded; rendering static geometry." : "Palette missing; using safe fallback palette.";
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    if (!ctx) {
-      elStatus.textContent = statusBase + " Canvas context unavailable; geometry skipped.";
-    } else {
-      elStatus.textContent = statusBase;
-
-      // ND-safe rationale: rendering happens once, layering preserves depth without motion.
-
-      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
-      updateStatus(paletteInfo.note + " Geometry rendered.");
-    }
-
-    init();
-
   </script>
 </body>
 </html>

--- a/helix-renderer/js/helix-renderer.mjs
+++ b/helix-renderer/js/helix-renderer.mjs
@@ -1,6 +1,4 @@
-
 // Per Texturas Numerorum, Spira Loquitur. //
-
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
@@ -10,118 +8,55 @@
     2) Tree-of-Life scaffold (10 sephirot + 22 paths)
     3) Fibonacci curve (log spiral polyline)
     4) Double-helix lattice (two phase-shifted strands with 144 struts)
+
+  Rationale: no motion, gentle contrast, and parameterization with numerology anchors.
 */
-
-// Small, pure, parameterized functions only; no animation, no external dependencies.
-
-// ND-safe: drawings are static with high-contrast yet gentle palette choices.
-
-export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM } = opts;
-  const layers = Array.isArray(palette.layers) ? palette.layers : [];
-  const fallback = palette.ink || "#ffffff";
-
-// ND-safe: all drawings are static with layered order for calm focus.
 
 const FALLBACK_LAYERS = ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"];
 
-function selectLayerTone(layers, index) {
-  if (!Array.isArray(layers)) return FALLBACK_LAYERS[index];
-  const tone = layers[index];
-  return typeof tone === "string" ? tone : FALLBACK_LAYERS[index];
-}
-
+// Exported pure function orchestrating the four geometry layers.
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
-
   const safeBg = typeof palette.bg === "string" ? palette.bg : "#0b0b12";
+  const safeInk = typeof palette.ink === "string" ? palette.ink : "#e8e8f0";
+  const layers = Array.isArray(palette.layers) && palette.layers.length ? palette.layers : FALLBACK_LAYERS;
+
   ctx.save();
   ctx.fillStyle = safeBg;
   ctx.fillRect(0, 0, width, height);
   ctx.restore();
 
-  // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix crown.
-  const vesicaTone = selectLayerTone(palette.layers, 0);
-  const treeNodeTone = selectLayerTone(palette.layers, 1);
-  const treePathTone = selectLayerTone(palette.layers, 2);
-  const fibonacciTone = selectLayerTone(palette.layers, 3);
-  const helixStrandTone = selectLayerTone(palette.layers, 4);
-  const latticeTone = selectLayerTone(palette.layers, 5);
+  const tones = {
+    vesica: {
+      rim: pickTone(layers, 0, safeInk),
+      grid: pickTone(layers, 1, safeInk)
+    },
+    tree: {
+      path: pickTone(layers, 2, safeInk),
+      node: pickTone(layers, 1, safeInk)
+    },
+    fibonacci: pickTone(layers, 3, safeInk),
+    helix: {
+      strand: pickTone(layers, 4, safeInk),
+      lattice: pickTone(layers, 5, safeInk)
+    }
+  };
 
-  drawVesica(ctx, width, height, vesicaTone, NUM);
-  drawTree(ctx, width, height, treeNodeTone, treePathTone, NUM);
-  drawFibonacci(ctx, width, height, fibonacciTone, NUM);
-  drawHelix(ctx, width, height, helixStrandTone, latticeTone, NUM);
+  drawVesica(ctx, width, height, tones.vesica, NUM);
+  drawTree(ctx, width, height, tones.tree, NUM);
+  drawFibonacci(ctx, width, height, tones.fibonacci, NUM);
+  drawHelix(ctx, width, height, tones.helix, NUM);
 }
 
-// L1 Vesica field: soft intersecting circles, gentle grid
-function drawVesica(ctx, w, h, color, NUM) {
-  ctx.save();
-  const r = Math.min(w, h) / NUM.THREE; // radius tied to numerology
-
-  const layers = Array.isArray(palette.layers) ? palette.layers : [];
-  const ink = palette.ink || "#e8e8f0";
-
-  // Layer foundation: fill background first to anchor the canvas in calm darkness.
-  ctx.save();
-
-  ctx.fillStyle = palette.bg || "#000000";
-
-  ctx.fillStyle = palette.bg || "#0b0b12";
-
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-
-  // Layer order preserves depth: vesica base, tree scaffold, spiral path, helix lattice crown.
-  drawVesica(ctx, width, height, {
-
-    rim: pickColor(layers, 0, fallback),
-    grid: pickColor(layers, 1, fallback)
-  }, NUM);
-
-  drawTree(ctx, width, height, {
-    path: pickColor(layers, 2, fallback),
-    node: pickColor(layers, 3, fallback)
-  }, NUM);
-
-  drawFibonacci(ctx, width, height, pickColor(layers, 4, fallback), NUM);
-
-  drawHelix(ctx, width, height, {
-    strand: pickColor(layers, 5, fallback),
-    lattice: pickColor(layers, 0, fallback)
-
-    rim: pickColor(layers, 0, ink),
-    grid: pickColor(layers, 1, ink)
-  }, NUM);
-
-  drawTree(ctx, width, height, {
-    path: pickColor(layers, 2, ink),
-    node: pickColor(layers, 3, ink)
-  }, NUM);
-
-  drawFibonacci(ctx, width, height, pickColor(layers, 4, ink), NUM);
-
-  drawHelix(ctx, width, height, {
-    strand: pickColor(layers, 5, ink),
-    lattice: pickColor(layers, 0, ink)
-
-  }, NUM);
+function pickTone(list, index, fallback) {
+  if (!Array.isArray(list)) return fallback;
+  const tone = list[index];
+  return typeof tone === "string" ? tone : fallback;
 }
 
-function pickColor(list, index, fallback) {
-  return list[index] || fallback;
-}
-
-
-// L1 Vesica field: soft intersecting circles + numerological grid.
-function drawVesica(ctx, w, h, colors, NUM) {
-  const radius = Math.min(w, h) / NUM.THREE;
-
-// L1 Vesica field: intersecting circles and a gentle grid grounded in numerology.
+// L1 Vesica field: intersecting circles and a gentle numerological grid.
 function drawVesica(ctx, w, h, tones, NUM) {
   const radius = Math.min(w, h) / NUM.THREE;
-
-
   const cx = w / 2;
   const cy = h / 2;
 
@@ -133,16 +68,9 @@ function drawVesica(ctx, w, h, tones, NUM) {
   ctx.arc(cx + radius / 2, cy, radius, 0, Math.PI * 2);
   ctx.stroke();
 
-  
-  // Subtle vesica grid using 7 vertical and 11 horizontal guides.
-  ctx.strokeStyle = colors.grid;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.6; // ND-safe translucency keeps the grid gentle.
-
   ctx.strokeStyle = tones.grid;
   ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.5; // ND-safe translucency keeps the grid supportive, not overwhelming.
-
+  ctx.globalAlpha = 0.45; // ND-safe translucency keeps the grid gentle.
 
   const verticalStep = radius / NUM.SEVEN;
   ctx.beginPath();
@@ -153,261 +81,154 @@ function drawVesica(ctx, w, h, tones, NUM) {
   }
   ctx.stroke();
 
-
   const horizontalStep = radius / NUM.ELEVEN;
   ctx.beginPath();
   for (let j = -NUM.ELEVEN; j <= NUM.ELEVEN; j++) {
     const y = cy + j * horizontalStep;
-
-  ctx.restore();
-}
-
-// L2 Tree-of-Life: 10 nodes + 22 paths (NUM.TWENTYTWO)
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  ctx.save();
-  const stepY = h / NUM.ELEVEN; // vertical rhythm
-
-
-  const horizontalStep = (radius * 2) / NUM.ELEVEN;
-  ctx.beginPath();
-  for (let j = 0; j <= NUM.ELEVEN; j++) {
-    const y = cy - radius + j * horizontalStep;
-
     ctx.moveTo(cx - radius, y);
     ctx.lineTo(cx + radius, y);
   }
   ctx.stroke();
-
   ctx.restore();
 }
 
-
-// L2 Tree-of-Life: 10 nodes + 22 connective paths.
-function drawTree(ctx, w, h, colors, NUM) {
-  const verticalStep = h / NUM.ELEVEN;
-  const centerX = w / 2;
-  const pillarOffset = (w / NUM.THREE) / 2;
-
-// L2 Tree-of-Life scaffold: 10 nodes and 22 paths for steady ascent.
+// L2 Tree-of-Life scaffold: 10 nodes and 22 connective paths.
 function drawTree(ctx, w, h, tones, NUM) {
-  const stepY = h / NUM.ELEVEN;
-
-  const xCenter = w / 2;
-  const xOffset = w / NUM.THREE / 2; // Three pillars define lateral spacing.
-
-
-  const nodes = buildTreeNodes(centerX, pillarOffset, verticalStep);
+  const nodes = buildTreeNodes(w, h, NUM);
   const paths = buildTreePaths();
 
   ctx.save();
   ctx.strokeStyle = tones.path;
-  ctx.lineWidth = 1;
-  ctx.lineCap = "round";
-  for (const [from, to] of paths) {
-    const start = nodes[from];
-    const end = nodes[to];
+  ctx.lineWidth = 1.5;
+  ctx.globalAlpha = 0.7; // ND-safe: paths stay soft yet legible.
+  for (const [aIndex, bIndex] of paths) {
+    const a = nodes[aIndex];
+    const b = nodes[bIndex];
     ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
 
-  const nodeRadius = Math.min(w, h) / (NUM.THREE * NUM.ELEVEN);
-
-  ctx.fillStyle = colors.node;
-
+  ctx.globalAlpha = 1;
   ctx.fillStyle = tones.node;
-
+  const nodeRadius = Math.max(4, Math.min(w, h) / NUM.ONEFORTYFOUR * 3);
   for (const node of nodes) {
     ctx.beginPath();
     ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
   }
   ctx.restore();
-
-
 }
 
+function buildTreeNodes(w, h, NUM) {
+  const centerX = w / 2;
+  const pillarOffset = (w / NUM.THREE) / 2;
+  const stepY = h / (NUM.ELEVEN + 2); // Room for calm breathing space top and bottom.
 
-function buildTreeNodes(centerX, offsetX, stepY) {
   return [
-    { x:centerX, y:stepY },
-    { x:centerX + offsetX, y:stepY * 2 },
-    { x:centerX - offsetX, y:stepY * 2 },
-    { x:centerX + offsetX, y:stepY * 4 },
-    { x:centerX - offsetX, y:stepY * 4 },
-    { x:centerX, y:stepY * 5 },
-    { x:centerX + offsetX, y:stepY * 7 },
-    { x:centerX - offsetX, y:stepY * 7 },
-    { x:centerX, y:stepY * 8 },
-    { x:centerX, y:stepY * 10 }
-
-function buildTreeNodes(center, offset, stepY) {
-  // Ten sephirot arranged in tri-column symmetry.
-  return [
-    { x:center, y:stepY },
-    { x:center + offset, y:stepY * 2 },
-    { x:center - offset, y:stepY * 2 },
-    { x:center + offset, y:stepY * 4 },
-    { x:center - offset, y:stepY * 4 },
-    { x:center, y:stepY * 5 },
-    { x:center + offset, y:stepY * 7 },
-    { x:center - offset, y:stepY * 7 },
-    { x:center, y:stepY * 8 },
-    { x:center, y:stepY * 10 }
-
+    { x:centerX, y:stepY * 1 },
+    { x:centerX - pillarOffset, y:stepY * 2 },
+    { x:centerX + pillarOffset, y:stepY * 2 },
+    { x:centerX, y:stepY * 3 },
+    { x:centerX - pillarOffset, y:stepY * 4 },
+    { x:centerX + pillarOffset, y:stepY * 4 },
+    { x:centerX - pillarOffset, y:stepY * 5 },
+    { x:centerX + pillarOffset, y:stepY * 5 },
+    { x:centerX, y:stepY * 6 },
+    { x:centerX, y:stepY * 7 }
   ];
 }
 
 function buildTreePaths() {
-  // Twenty-two paths honoring the classic Tree-of-Life connections.
   return [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
-    [5,6],[5,7],[6,7],[6,8],[7,8],[8,9],[5,8],[1,5],
-    [2,5],[3,6],[4,7],[1,6],[2,7],[0,5]
+    [0,1],[0,2],[1,2],
+    [1,3],[2,3],
+    [1,4],[2,5],
+    [3,4],[3,5],[4,5],
+    [4,6],[5,7],[6,7],
+    [4,8],[5,8],[6,8],[7,8],
+    [6,9],[7,9],[8,9],[4,9],[5,9]
   ];
-
 }
 
-
-// L3 Fibonacci curve: static polyline log spiral with 99 calm points.
-function drawFibonacci(ctx, w, h, color, NUM) {
+// L3 Fibonacci curve: static logarithmic spiral honoring 33 steps per turn and 99 points total.
+function drawFibonacci(ctx, w, h, tone, NUM) {
+  const totalPoints = NUM.NINETYNINE;
+  const cx = w / 2;
+  const cy = h / 2;
+  const baseRadius = Math.min(w, h) / NUM.THIRTYTHREE;
   const phi = (1 + Math.sqrt(5)) / 2;
-
-// L3 Fibonacci curve: 99 static points create a calm logarithmic spiral.
-function drawFibonacci(ctx, w, h, color, NUM) {
+  const angleStep = (Math.PI * 2) / NUM.THIRTYTHREE;
+  const maxRadius = Math.min(w, h) / 2.1;
 
   ctx.save();
-  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
-
-  const phi = (1 + Math.sqrt(5)) / 2;
-
-
-  const centerX = w / 2;
-  const centerY = h / 2;
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
-  const maxRadius = Math.hypot(w, h) / 2;
-
-  ctx.save();
-  ctx.strokeStyle = color;
+  ctx.strokeStyle = tone;
   ctx.lineWidth = 2;
-  ctx.lineJoin = "round";
+  ctx.globalAlpha = 0.85;
   ctx.beginPath();
-  for (let i = 0; i < NUM.NINETYNINE; i++) {
-
-    const angle = i * (Math.PI / NUM.ELEVEN); // gentle sweep tied to 11.
-
-    const angle = i * (Math.PI / NUM.ELEVEN);
-
-    const radius = Math.min(maxRadius, scale * Math.pow(phi, i / NUM.NINE));
-    const x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
+  for (let i = 0; i < totalPoints; i++) {
+    const angle = i * angleStep;
+    const radius = Math.min(baseRadius * Math.pow(phi, i / NUM.NINE), maxRadius);
+    const x = cx + Math.cos(angle) * radius;
+    const y = cy + Math.sin(angle) * radius;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
   ctx.restore();
 }
 
-
-// L4 Double-helix lattice: two sine strands with 144 vertical struts.
-function drawHelix(ctx, w, h, colors, NUM) {
-  const centerY = h / 2;
-  const amplitude = h / NUM.THREE;
-  const steps = NUM.ONEFORTYFOUR;
-  const frequency = NUM.THREE; // three gentle twists across the width.
-
-  ctx.save();
-
-  ctx.strokeStyle = colors.lattice;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.6; // ND-safe translucency keeps lattice supportive, not overpowering.
-  for (let i = 0; i <= steps; i++) {
-    const ratio = steps === 0 ? 0 : i / steps;
-    const x = ratio * w;
-    const phase = ratio * frequency * Math.PI;
-    const yA = centerY + amplitude * Math.sin(phase);
-    const yB = centerY + amplitude * Math.sin(phase + Math.PI);
-
-// L4 Double-helix lattice: two phase-shifted sine waves with 144 struts
-function drawHelix(ctx, w, h, strandColor, latticeColor, NUM) {
-  ctx.save();
-  const centerY = h / 2;
-  const amp = h / NUM.THREE; // amplitude linked to threefold nature
-  const steps = NUM.ONEFORTYFOUR; // lattice count
-  const span = steps - 1 || 1; // ensures the final strut reaches the far edge without extra lines
-  const freq = NUM.THREE; // three full twists
-
-// L4 Double-helix lattice: twin strands bridged by 144 static struts.
+// L4 Double-helix lattice: two sine-based strands linked with 144 struts.
 function drawHelix(ctx, w, h, tones, NUM) {
-  const steps = NUM.ONEFORTYFOUR;
-  const span = Math.max(1, steps - 1);
+  const segments = NUM.ONEFORTYFOUR;
+  const amplitude = h / NUM.THREE / 2;
   const baseY = h / 2;
-  const amplitude = h / NUM.THREE;
-  const frequency = NUM.THREE; // Three full waves maintain the trifold pattern.
+  const stepX = w / segments;
+  const phaseStep = (Math.PI * 2) / (NUM.ELEVEN * NUM.THREE); // Soft frequency for calm pacing.
+
+  const strandA = [];
+  const strandB = [];
+  for (let i = 0; i <= segments; i++) {
+    const x = i * stepX;
+    const phase = i * phaseStep;
+    strandA.push({ x, y: baseY + Math.sin(phase) * amplitude });
+    strandB.push({ x, y: baseY + Math.sin(phase + Math.PI) * amplitude });
+  }
 
   ctx.save();
-
-
   ctx.strokeStyle = tones.lattice;
   ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.55; // Struts stay supportive without overpowering the strands.
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = ratio * w;
-    const phase = ratio * frequency * Math.PI;
-    const yA = baseY + amplitude * Math.sin(phase);
-    const yB = baseY + amplitude * Math.sin(phase + Math.PI);
-
+  ctx.globalAlpha = 0.35; // Lattice stays subtle to preserve depth without overstimulation.
+  for (let i = 0; i < segments; i++) {
+    const a = strandA[i];
+    const b = strandB[i];
     ctx.beginPath();
-    ctx.moveTo(x, yA);
-    ctx.lineTo(x, yB);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
 
-  ctx.globalAlpha = 1;
-
-  ctx.strokeStyle = colors.strand;
-  ctx.lineWidth = 2;
-
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const ratio = steps === 0 ? 0 : i / steps;
-    const x = ratio * w;
-    const phase = ratio * frequency * Math.PI;
-    const y = centerY + amplitude * Math.sin(phase);
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const ratio = steps === 0 ? 0 : i / steps;
-    const x = ratio * w;
-    const phase = ratio * frequency * Math.PI + Math.PI;
-    const y = centerY + amplitude * Math.sin(phase);
-
+  ctx.globalAlpha = 0.9;
   ctx.strokeStyle = tones.strand;
   ctx.lineWidth = 2;
-  drawStrand(ctx, steps, span, w, baseY, amplitude, frequency, 0);
-  drawStrand(ctx, steps, span, w, baseY, amplitude, frequency, Math.PI);
-
+  drawStrand(ctx, strandA);
+  drawStrand(ctx, strandB);
   ctx.restore();
 }
 
-function drawStrand(ctx, steps, span, width, baseY, amplitude, frequency, phaseShift) {
+function drawStrand(ctx, points) {
   ctx.beginPath();
-  for (let i = 0; i < steps; i++) {
-    const ratio = i / span;
-    const x = ratio * width;
-    const phase = ratio * frequency * Math.PI + phaseShift;
-    const y = baseY + amplitude * Math.sin(phase);
-
-    if (i === 0) ctx.moveTo(x, y);
-    else ctx.lineTo(x, y);
+  for (let i = 0; i < points.length; i++) {
+    const pt = points[i];
+    if (i === 0) {
+      ctx.moveTo(pt.x, pt.y);
+    } else {
+      ctx.lineTo(pt.x, pt.y);
+    }
   }
   ctx.stroke();
-
-  ctx.restore();
 }


### PR DESCRIPTION
## Summary
- Rebuilt the offline helix renderer entry point with a calm fallback palette loader and ND-safe status messaging.
- Implemented a clean helix-renderer module that draws vesica, tree-of-life, Fibonacci, and helix layers using numerology anchors.
- Updated the renderer README to outline files, palette fallback behavior, ND-safe choices, and offline usage.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdcd7d09088328921e8eea4b01865b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline-first renderer with zero dependencies and a single static render.
  - Clear status line indicates palette load success or safe fallback.
  - Automatic trauma-informed fallback palette; page colors update for legibility.

- Bug Fixes
  - More resilient palette loading/validation and clearer error messages.
  - Canvas context issues reported without clobbering existing status text.

- Refactor
  - Calmer, more predictable visuals while preserving layered depth.

- Documentation
  - README streamlined: files list, concise layer descriptions, ND-safe choices, numerology anchors, and offline usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->