### PR TITLE
chore: remove LFS pointer and inline hero placeholder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-*.png  filter=lfs diff=lfs merge=lfs -text
-*.jpg  filter=lfs diff=lfs merge=lfs -text
-*.jpeg filter=lfs diff=lfs merge=lfs -text
-*.webp filter=lfs diff=lfs merge=lfs -text
-*.avif filter=lfs diff=lfs merge=lfs -text
+# Git LFS disabled for static assets

--- a/site/assets/img/hero.avif
+++ b/site/assets/img/hero.avif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57160f8e8bee257dd6ac0501e4e8362f9bb4de699a2c9efbe128be3e127397bb
-size 87297

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>COSMOGENESIS — Cathedral of Circuits</title>
   <meta name="description" content="A living grimoire: sacred geometry, techno-occult research, and spiral learning." />
-  <link rel="preload" href="assets/img/hero.avif" as="image" />
+  <link rel="preload" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=" as="image" />
   <link rel="stylesheet" href="assets/css/atelier.css" />
   <link rel="stylesheet" href="assets/css/colors.css" />
 </head>
@@ -25,7 +25,7 @@
   <main id="main" class="vesica-bg tarot-overlay aurora">
     <section class="hero" aria-labelledby="hero-title">
       <figure class="hero-visual">
-        <img src="assets/img/hero.avif" width="1280" height="720" alt="Layered circuit sigil with calm indigo gradient." />
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=" width="1280" height="720" alt="Layered circuit sigil with calm indigo gradient." />
       </figure>
       <div class="hero-copy">
         <h1 id="hero-title">Cathedral of Circuits</h1>


### PR DESCRIPTION
## Summary
- document that Git LFS filters are disabled for static assets
- remove the LFS pointer hero asset and replace its references with a transparent data URL placeholder so Netlify builds do not require Git LFS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdda57180c8328a32fcfe1c735e920