### PR TITLE
Add Cathedral Visionary ruleset and refine offline renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -8,6 +8,11 @@ This renderer keeps the Stone Cathedral helix accessible without builds or netwo
 - `js/helix-renderer.mjs` – ES module exporting `renderHelix(ctx, options)`. All helpers are pure so the canvas state stays predictable.
 - `data/palette.json` – optional colour overrides. Remove or edit this file to retint the scene while staying offline.
 
+## Cathedral Visionary Ruleset Hook
+
+- `registry/universal.json` now registers the **Cathedral Visionary 1.0** ruleset.
+- Load `rulesets.cathedral_visionary_v1` to enforce Rosslyn geometry, Tara bands, and provenance metadata across renderers.
+
 ## Layer Order and Numerology Anchors
 
 1. **Vesica Field** – twin circles plus a numerology grid (3, 7, 11, 22) to ground the scene.

--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Cosmic Helix Renderer (Offline, ND-safe)</title>
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe styling: quiet contrast, no motion, centered breathing room */
+    /* ND-safe: calm contrast, no motion, generous spacing */
     :root {
       --bg:#0b0b12;
       --ink:#e8e8f0;
@@ -19,53 +19,42 @@
       padding:0;
       background:var(--bg);
       color:var(--ink);
-      font:15px/1.5 "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
     }
 
     header {
-      padding:16px 20px;
-      border-bottom:1px solid rgba(255,255,255,0.08);
+      padding:12px 16px;
+      border-bottom:1px solid #1d1d2a;
     }
 
     header strong {
-      display:block;
+      font-size:13px;
       letter-spacing:0.08em;
       text-transform:uppercase;
-      font-size:12px;
     }
 
-    #status {
+    .status {
       margin-top:4px;
       color:var(--muted);
-      font-size:13px;
-    }
-
-    main {
-      padding:24px 16px 48px;
-      display:flex;
-      flex-direction:column;
-      align-items:center;
-      gap:20px;
+      font-size:12px;
     }
 
     #stage {
       display:block;
-      width:100%;
-      max-width:1440px;
-      height:auto;
-      box-shadow:0 0 0 1px rgba(255,255,255,0.08);
-      background:#080810;
+      margin:16px auto;
+      box-shadow:0 0 0 1px #1d1d2a;
+      background:#090912;
     }
 
     .note {
-      max-width:720px;
+      max-width:900px;
+      margin:0 auto 16px;
+      padding:0 16px 24px;
       color:var(--muted);
-      text-align:center;
-      font-size:14px;
     }
 
     code {
-      background:rgba(255,255,255,0.05);
+      background:#11111a;
       padding:2px 4px;
       border-radius:3px;
     }
@@ -73,31 +62,53 @@
 </head>
 <body>
   <header>
-    <strong>Cosmic Helix Renderer</strong>
-    <span id="status">Loading palette…</span>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
-  <main>
-    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-    <p class="note">
-      Layers paint once: Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
-      Everything runs offline with ND-safe colours and no animation.
-    </p>
-  </main>
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const FALLBACK = {
-      bg:"#0b0b12",
-      ink:"#e8e8f0",
-      muted:"#a6a6c1",
-      layers:["#8ba8ff","#74d8f2","#98f7c4","#ffd8a8","#f6b8ff","#d8dcff"]
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache:"no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (error) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        muted:"#a6a6c1",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
     };
+
+    function applyShellColours(palette) {
+      document.documentElement.style.setProperty("--bg", palette.bg || defaults.palette.bg);
+      document.documentElement.style.setProperty("--ink", palette.ink || defaults.palette.ink);
+      document.documentElement.style.setProperty("--muted", palette.muted || defaults.palette.muted);
+    }
+
+    function isPalette(value) {
+      return Boolean(value) && typeof value.bg === "string" && typeof value.ink === "string";
+    }
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = isPalette(palette) ? palette : defaults.palette;
+    elStatus.textContent = isPalette(palette) ? "Palette loaded." : "Palette missing; using safe fallback.";
+    applyShellColours(active);
 
     const NUM = {
       THREE:3,
@@ -110,42 +121,14 @@
       ONEFORTYFOUR:144
     };
 
-    async function readPalette(path) {
-      try {
-        const response = await fetch(path, { cache:"no-store" });
-        if (!response.ok) throw new Error(String(response.status));
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    function applyShellColours(palette) {
-      document.documentElement.style.setProperty("--bg", palette.bg || FALLBACK.bg);
-      document.documentElement.style.setProperty("--ink", palette.ink || FALLBACK.ink);
-      document.documentElement.style.setProperty("--muted", palette.muted || FALLBACK.muted);
-    }
-
-    function isPalette(value) {
-      return Boolean(value) && typeof value.bg === "string" && typeof value.ink === "string";
-    }
-
-    const palette = await readPalette("./data/palette.json");
-    const activePalette = isPalette(palette) ? palette : FALLBACK;
-    const paletteMessage = isPalette(palette)
-      ? "Palette loaded."
-      : "Palette missing or blocked; using safe fallback.";
-
-    applyShellColours(activePalette);
-    statusEl.textContent = paletteMessage;
-
+    // ND-safe rationale: single render pass, soft palette, layered order without motion.
     renderHelix(ctx, {
       width:canvas.width,
       height:canvas.height,
       palette:{
-        bg:activePalette.bg,
-        ink:activePalette.ink,
-        layers:Array.isArray(activePalette.layers) ? activePalette.layers.slice() : FALLBACK.layers
+        bg:active.bg,
+        ink:active.ink,
+        layers:Array.isArray(active.layers) && active.layers.length > 0 ? active.layers.slice() : defaults.palette.layers
       },
       NUM
     });

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,6 +1,6 @@
 /*
   helix-renderer.mjs
-  Static renderer for the Cosmic Helix canvas.
+  ND-safe static renderer for the Cosmic Helix canvas.
   Layers paint bottom to top in four passes to preserve depth without motion:
     1) Vesica field with numerology grid
     2) Tree-of-Life scaffold (10 sephirot, 22 paths)
@@ -8,6 +8,8 @@
     4) Double-helix lattice with 144 struts
   All helpers are pure; they only touch arguments passed to them.
 */
+
+const PHI = (1 + Math.sqrt(5)) / 2;
 
 export function renderHelix(ctx, options) {
   const config = normaliseOptions(options);
@@ -65,7 +67,7 @@ function normaliseNumerology(NUM) {
 }
 
 function paintBackground(ctx, width, height, palette) {
-  /* ND-safe base: solid dusk tone with soft radial glow. */
+  /* ND-safe base: solid dusk tone with soft radial glow to avoid harsh contrast. */
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
@@ -155,7 +157,7 @@ function drawTreeOfLife(ctx, width, height, palette, NUM) {
   });
 
   ctx.fillStyle = hexToRgba(pickLayer(palette.layers, 1, palette.ink), 0.9);
-  const nodeRadius = Math.max(4, Math.min(width, height) / NUM.ONEFORTYFOUR * 3);
+  const nodeRadius = computeNodeRadius(width, height, NUM);
   nodes.forEach(node => {
     ctx.beginPath();
     ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
@@ -214,14 +216,13 @@ function buildSpiralPoints(width, height, NUM) {
   const centreX = width / 2;
   const centreY = height / 2;
   const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE;
-  const phi = (1 + Math.sqrt(5)) / 2;
   const angleStep = (Math.PI * 2) / NUM.THIRTYTHREE;
   const maxRadius = Math.min(width, height) / 2.1;
   const output = [];
 
   for (let i = 0; i < total; i += 1) {
     const angle = i * angleStep;
-    const radius = Math.min(baseRadius * Math.pow(phi, i / NUM.NINE), maxRadius);
+    const radius = Math.min(baseRadius * Math.pow(PHI, i / NUM.NINE), maxRadius);
     output.push({
       x: centreX + Math.cos(angle) * radius,
       y: centreY + Math.sin(angle) * radius
@@ -288,6 +289,10 @@ function drawPolyline(ctx, points) {
   ctx.stroke();
 }
 
+function computeNodeRadius(width, height, NUM) {
+  return Math.max(4, Math.min(width, height) / NUM.ONEFORTYFOUR * 3);
+}
+
 function pickLayer(layers, index, fallback) {
   if (!Array.isArray(layers)) return fallback;
   const tone = layers[index];
@@ -297,10 +302,10 @@ function pickLayer(layers, index, fallback) {
 function hexToRgba(hex, alpha) {
   const value = hex.replace("#", "");
   if (value.length !== 6) {
-    return `rgba(255,255,255,${alpha})`;
+    return "rgba(255,255,255," + alpha + ")";
   }
   const r = parseInt(value.slice(0, 2), 16);
   const g = parseInt(value.slice(2, 4), 16);
   const b = parseInt(value.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
+  return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
 }

--- a/registry/universal.json
+++ b/registry/universal.json
@@ -1,0 +1,62 @@
+{
+  "rulesets": {
+    "cathedral_visionary_v1": {
+      "name": "Cathedral Visionary 1.0",
+      "about": "Standards for rendering Rosslyn-inspired cathedrals, 21 Tara bands, and Morgan le Fey realms at atelier and Vienna Fantastic Realism quality.",
+      "composition": {
+        "full_view": true,
+        "no_cropping": true,
+        "frame_ratio": "phi (1:1.618)",
+        "center_axis": "vesica/double tree symmetry"
+      },
+      "geometry": {
+        "forms": ["octagon", "hexagram", "vesica", "cube"],
+        "double_tree": true,
+        "fractals": "allowed if phi-harmonic",
+        "ratios": ["phi", "pi", "3:2", "5:4", "7:4"]
+      },
+      "color_light": {
+        "taras": 21,
+        "style": "aurora-like silk bands",
+        "gold": "kintsugi lines highlight geometry",
+        "light_source": "inner radiant"
+      },
+      "style": {
+        "art_school": "Vienna Fantastic Realism (Fuchs, Hausner, Brauer)",
+        "japanese_principles": ["ma (spaciousness)", "shibumi (elegance)", "wabi-sabi (sacred asymmetry)"],
+        "mythic_context": "Morgan le Fey realm, enchanted order not chaos"
+      },
+      "perspective": {
+        "include_sky": true,
+        "include_ground": true,
+        "horizon_position": "phi from bottom",
+        "no_distortion": true
+      },
+      "provenance": {
+        "lineage": [
+          "Rosslyn Chapel geometric analyses",
+          "Vienna Fantastic Realism ateliers",
+          "Cosmogenesis learning engine field notes"
+        ],
+        "license": "CC BY-NC",
+        "curator": "Rebecca Respawn",
+        "author": "Virelai Ezra Lux / Rebecca Respawn",
+        "date": "2025-02-13",
+        "notes": "Encoded for Codex 144:99 so every renderer enforces the Rosslyn constants and Tara harmonics.",
+        "ruleset_id": "cathedral_visionary_v1",
+        "geometry": ["octagon", "hexagram", "vesica", "cube"],
+        "color_system": "21 Taras + gold",
+        "ratios": ["phi", "3:2", "5:4", "7:4"],
+        "style_refs": ["Vienna Fantastic Realism", "Japanese Ma/Shibumi", "Rosslyn Chapel"],
+        "full_view": true
+      },
+      "worker_checks": [
+        "Confirm frame ratio = phi",
+        "Confirm full cathedral structure visible",
+        "Apply 21 Tara auroras correctly mapped",
+        "Embed provenance metadata in artifact",
+        "Reject render if symmetry, ratio, or provenance checks fail"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- register the Cathedral Visionary 1.0 ruleset in `registry/universal.json` with provenance and worker checks
- refresh the offline renderer shell to keep ND-safe styling and clearer palette fallbacks
- document the new ruleset hook and keep the helix renderer helpers explicit about ND-safe layering

## Testing
- not run (static HTML/JS updates)

------
https://chatgpt.com/codex/tasks/task_e_68d03c8556dc8328b7b42c0b6b3ed368