### PR TITLE
Refresh offline helix renderer entrypoint and add resolver helper

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -4,18 +4,22 @@ Static, offline renderer that paints the Cosmic Helix layers on a 1440x900 canva
 
 ## Layers and Safety
 
-- Vesica field anchors the scene with intersecting circles derived from constants 3, 7, 9, 11.
-- Tree-of-Life scaffold plots 10 sephirot plus Daath and wires 22 static paths.
+- Vesica field anchors the scene with intersecting circles derived from constants 3, 7, 9, and 11.
+- Tree-of-Life scaffold plots 10 sephirot plus Daath and wires 22 static paths to respect the canon.
 - Fibonacci curve traces three calm turns of a logarithmic spiral for gentle motion cues without animation.
-- Double-helix lattice adds two strands and 22 crossbars to complete the weave.
+- Double-helix lattice adds two strands, 22 crossbars, and a central spine so the weave stays grounded.
 
-Design notes are written directly in `js/helix-renderer.mjs`. Each helper is pure, and comments explain the ND-safe rationale (no motion, soft gradients, layered ordering).
+Design notes sit directly inside `js/helix-renderer.mjs`. Each helper is pure and includes comments about ND-safe rationale: no motion, soft gradients, and a clear paint order for layered geometry.
+
+## Numerology Anchors
+
+The renderer keeps the requested constants close at hand. The default `NUM` object exposes 3, 7, 9, 11, 22, 33, 99, and 144. Modify the object before calling `renderHelix` if you need different ratios for another study.
 
 ## Files
 
-- `index.html` - entry point with header status line and a `<canvas>` sized to 1440x900.
-- `js/helix-renderer.mjs` - ES module exporting `renderHelix(ctx, options)`; contains pure helpers for each layer.
-- `data/palette.json` - optional palette override. Remove or edit to retint the renderer while staying offline.
+- `index.html` – entry point with header status line and a `<canvas>` sized to 1440x900.
+- `js/helix-renderer.mjs` – ES module exporting `renderHelix(ctx, options)`; contains pure helpers for each layer.
+- `data/palette.json` – optional palette override. Remove or edit to retint the renderer while staying offline. When missing, the script posts a small notice and uses internal ND-safe colors.
 
 ## Usage (Offline)
 

--- a/assets/js/resolve.js
+++ b/assets/js/resolve.js
@@ -1,0 +1,12 @@
+// Minimal helper to call the Cosmogenesis learning engine.
+// No retries or animation; callers can decide how to surface results.
+export async function resolveWorker(profile){
+  const url = "https://cosmogenesis-learning-engine.fly.io/resolve";
+  const res = await fetch(url,{
+    method:"POST",
+    headers:{ "content-type":"application/json" },
+    body: JSON.stringify(profile)
+  });
+  if(!res.ok) throw new Error("resolver error");
+  return res.json();
+}

--- a/index.html
+++ b/index.html
@@ -3,58 +3,30 @@
 <head>
   <meta charset="utf-8">
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
-
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-
   <meta name="color-scheme" content="light dark">
-  <!-- Integration: this index keeps the renderer offline for cathedral study; no lore overwritten. -->
   <style>
-    /* ND-safe design: calm contrast, no animation, generous breathing room */
+    /* ND-safe: calm contrast, no motion, generous breathing room */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-
-    .status { color:var(--muted); font-size:12px; }
-    #opus { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
-    #hero-art { display:flex; justify-content:center; padding-bottom:24px; }
-    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
-
     header strong { letter-spacing:0.08em; text-transform:uppercase; font-size:12px; }
     .status { color:var(--muted); font-size:12px; margin-top:2px; }
     main { padding:16px; display:flex; flex-direction:column; gap:12px; align-items:center; }
     #stage { display:block; width:100%; max-width:1440px; height:auto; box-shadow:0 0 0 1px #1d1d2a; background:#080810; }
     .note { max-width:900px; color:var(--muted); font-size:13px; text-align:center; }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
-    @media (prefers-reduced-motion: reduce) { * { animation:none !important; transition:none !important; } }
-
   </style>
 </head>
 <body>
   <header>
-
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status">Static fallback ready; art mounts only when manifest passes policy.</div>
-  </header>
-
-  <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
-  <div id="hero-art"></div>
-
-  <script type="module">
-    import { paintOctagram } from "/assets/js/first-paint-octagram.js";
-    import { mountArt } from "/assets/js/art-loader.js";
-    paintOctagram();
-    mountArt();
-
-    <strong>Cosmic Helix Renderer</strong>
-    <div class="status" id="status">Loading palette...</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
   <main>
     <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-    <p class="note">Layers render once: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. Palette stays ND-safe; open this file directly with no network.</p>
+    <p class="note">This static renderer paints four calm layers in order: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open this file directly—no external network calls occur.</p>
   </main>
-
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
@@ -102,7 +74,6 @@
       palette: activePalette,
       NUM
     });
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify the offline helix index to paint the four requested layers with fallback palette messaging
- document numerology anchors and palette behaviour in README_RENDERER
- add an ES module helper that posts to the Cosmogenesis learning engine resolver endpoint

## Testing
- not run (static content only)

------
https://chatgpt.com/codex/tasks/task_e_68d02aed78f0832891a0cddbaa14c602