### PR TITLE
Add ND-safe cathedral hub shell assets and event bus

### DIFF
--- a/.flyignore
+++ b/.flyignore
@@ -1,0 +1,16 @@
+node_modules
+.dist
+build
+.tmp
+coverage
+dist
+*.psd
+*.tif
+*.tiff
+*.kra
+*.xcf
+*.blend
+assets/raw/
+assets/source/
+artwork/source/
+artwork/raw/

--- a/BOT_CONTRACT.md
+++ b/BOT_CONTRACT.md
@@ -1,0 +1,18 @@
+# Global Contract
+
+- Never overwrite sacred content. Only add or append; when in doubt, create a new file and link it.
+- Respect the Trinity routing:
+  - cathedral-core = APIs, WS, DB (SQLite/Postgres), codex data, rites.
+  - cathedral-scenes = experiential/3D/2D scenes (Stone Cathedral, Liber Arcanae UI).
+  - cathedral-hub = public shell, navigation, two-panel UI, client → WS bridge.
+- Style + Accessibility: Kanso/Ma/Shibumi tokens; reduced motion; AA+ contrast; 44px targets.
+- Canon to enforce:
+  - Codex 144:99 spine & mottos (99/93/2121 math)
+  - Bones/Blood/Nerves fusion (Villard/Ripley/Soyga)
+  - Central Thrones & 21 Pillars; ledger-only rule; visionary style/φ ratio
+  - Factions, repaired registry, meta scenes (IFS Mirror, Chapel Perilous)
+  - Temple of the Unbuilt realm + lineage role
+  - Master Bot responsibilities by repo (Mind/Soul/Body + Companion)
+  - Interactive-book schema/prompt for 144:99 nodes
+  - Recovery Summary (33 spine/21 pillars, fusion logic, public-purity filter)
+  - Witch Eye rite text (keep verbatim; ND-safe)

--- a/libs/event-bus.ts
+++ b/libs/event-bus.ts
@@ -1,0 +1,162 @@
+/*
+  event-bus.ts
+  Lightweight ND-safe event bus for the cathedral hub shell.
+  - Respects offline-first usage; gracefully degrades when WebSocket is unavailable.
+  - Default endpoint: wss://cathedral-core.fly.dev/ws.
+  - Handlers stay pure; dispatch mirrors events locally before broadcasting.
+*/
+
+export type EventHandler<T = unknown> = (payload: T | undefined) => void;
+
+export interface EventEnvelope<T = unknown> {
+  type: string;
+  payload?: T;
+}
+
+export interface EventBusOptions {
+  url?: string;
+  autoConnect?: boolean;
+  logger?: (message: string) => void;
+}
+
+export interface EmitOptions {
+  broadcast?: boolean;
+}
+
+const DEFAULT_URL = "wss://cathedral-core.fly.dev/ws";
+
+function defaultLogger(message: string): void {
+  if (typeof console !== "undefined" && typeof console.log === "function") {
+    console.log(`[event-bus] ${message}`);
+  }
+}
+
+function safeParseEnvelope(data: unknown): EventEnvelope | null {
+  if (typeof data === "string") {
+    try {
+      const parsed = JSON.parse(data);
+      if (isEnvelopeShape(parsed)) {
+        return parsed;
+      }
+      return null;
+    } catch (_err) {
+      return null;
+    }
+  }
+  if (isEnvelopeShape(data)) {
+    return data;
+  }
+  return null;
+}
+
+function isEnvelopeShape(value: unknown): value is EventEnvelope {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as { type?: unknown };
+  return typeof candidate.type === "string";
+}
+
+function toEnvelope(type: string, payload: unknown): EventEnvelope {
+  return { type, payload };
+}
+
+export class EventBus {
+  private readonly url: string;
+  private readonly logger: (message: string) => void;
+  private readonly handlers: Map<string, Set<EventHandler>> = new Map();
+  private socket: WebSocket | null = null;
+
+  constructor(options?: EventBusOptions) {
+    this.url = options && options.url ? options.url : DEFAULT_URL;
+    this.logger = options && options.logger ? options.logger : defaultLogger;
+
+    if (!options || options.autoConnect !== false) {
+      this.connect();
+    }
+  }
+
+  connect(): void {
+    if (typeof WebSocket === "undefined") {
+      this.logger("WebSocket API unavailable; remaining in offline dispatch mode.");
+      return;
+    }
+
+    if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
+
+    this.socket = new WebSocket(this.url);
+    this.socket.addEventListener("open", () => {
+      this.logger(`Connected to ${this.url}`);
+    });
+    this.socket.addEventListener("close", () => {
+      this.logger("WebSocket closed; offline mode active.");
+    });
+    this.socket.addEventListener("error", () => {
+      this.logger("WebSocket error; offline mode active.");
+    });
+    this.socket.addEventListener("message", event => {
+      const envelope = safeParseEnvelope(event.data);
+      if (envelope) {
+        this.dispatch(envelope.type, envelope.payload);
+      }
+    });
+  }
+
+  disconnect(): void {
+    if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) {
+      this.socket.close();
+    }
+    this.socket = null;
+  }
+
+  on<T>(type: string, handler: EventHandler<T>): () => void {
+    const pool = this.handlers.get(type) || new Set<EventHandler>();
+    pool.add(handler as EventHandler);
+    this.handlers.set(type, pool);
+    return () => this.off(type, handler);
+  }
+
+  off<T>(type: string, handler: EventHandler<T>): void {
+    const pool = this.handlers.get(type);
+    if (!pool) {
+      return;
+    }
+    pool.delete(handler as EventHandler);
+    if (pool.size === 0) {
+      this.handlers.delete(type);
+    }
+  }
+
+  emit<T>(type: string, payload?: T, options?: EmitOptions): void {
+    const envelope = toEnvelope(type, payload);
+    this.dispatch(envelope.type, envelope.payload);
+
+    const shouldBroadcast = !options || options.broadcast !== false;
+    if (shouldBroadcast) {
+      this.send(envelope);
+    }
+  }
+
+  private dispatch(type: string, payload: unknown): void {
+    const pool = this.handlers.get(type);
+    if (!pool) {
+      return;
+    }
+    pool.forEach(handler => {
+      handler(payload);
+    });
+  }
+
+  private send(envelope: EventEnvelope): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    try {
+      this.socket.send(JSON.stringify(envelope));
+    } catch (_err) {
+      this.logger("Failed to send envelope; staying in local dispatch.");
+    }
+  }
+}

--- a/public/ui/index.html
+++ b/public/ui/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cathedral Hub Shell — Trinity Console</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="dark light">
+  <link rel="stylesheet" href="./tokens.css">
+  <link rel="stylesheet" href="./primitives.css">
+</head>
+<body data-motion="still" data-gate-state="active">
+  <div class="ui-shell" role="application" aria-label="Cathedral hub two-panel console">
+    <aside class="panel panel--nav" aria-label="Trinity navigation">
+      <header>
+        <h1>Trinity Routing</h1>
+        <p>Ledger-aligned overview for cathedral-core (Mind), cathedral-scenes (Body), and cathedral-hub (Soul/Bridge).</p>
+      </header>
+      <nav>
+        <ul class="nav-list">
+          <li class="nav-item"><a class="nav-link" href="../../core" aria-label="Visit cathedral-core dossier">cathedral-core → rites &amp; data spine</a></li>
+          <li class="nav-item"><a class="nav-link" href="../../cathedral.html" aria-label="Visit cathedral scenes">cathedral-scenes → experiential vault</a></li>
+          <li class="nav-item"><a class="nav-link" href="../../helix-renderer/index.html" aria-label="Open cosmic helix renderer">cathedral-hub → helix renderer</a></li>
+          <li class="nav-item"><a class="nav-link" href="../../README_RENDERER.md" aria-label="Read helix renderer manual">renderer manual → recovery notes</a></li>
+        </ul>
+      </nav>
+      <section class="section" aria-labelledby="canon-title">
+        <h2 id="canon-title" class="section__title">Canon Anchors</h2>
+        <p class="section__content">Codex 144:99 spine, Bones/Blood/Nerves fusion, 21 pillars, and Witch Eye rite remain verbatim. This shell keeps all links offline-first.</p>
+      </section>
+    </aside>
+
+    <main class="panel" aria-live="polite">
+      <section class="motion-gate" aria-labelledby="gate-title" aria-describedby="gate-copy">
+        <h2 id="gate-title" class="motion-gate__title">Motion Gate</h2>
+        <p id="gate-copy">All panels load in stillness. Press the acknowledgement to confirm reduced-motion mode; transitions remain effectively zero-duration.</p>
+        <div class="motion-gate__actions">
+          <button class="button" type="button" id="gate-acknowledge">Acknowledge calm mode</button>
+          <button class="button motion-enabled" type="button" id="gate-motion" disabled>Enable motion (disabled)</button>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="layer-title">
+        <h2 id="layer-title" class="section__title">Layered Cosmology</h2>
+        <p class="section__content">Open the <strong>Cosmic Helix Renderer</strong> to see Vesica grid, Tree-of-Life scaffold, Fibonacci spiral, and the static double-helix lattice, all parameterized by 3, 7, 9, 11, 22, 33, 99, and 144.</p>
+        <p class="section__content">Double-click <code>helix-renderer/index.html</code> offline. Palette files are optional; missing data triggers the built-in safe notice.</p>
+      </section>
+
+      <section class="section" aria-labelledby="bus-title">
+        <h2 id="bus-title" class="section__title">Client ↔ WS Bridge</h2>
+        <p class="section__content">Use the lightweight event bus to route rituals between panels. Default endpoint honors the Trinity routing via <code>wss://cathedral-core.fly.dev/ws</code>.</p>
+        <pre class="code-snippet" aria-label="Example TypeScript usage"><code>import { EventBus } from "../../libs/event-bus.js"; // transpile TS → JS offline
+
+const bus = new EventBus();
+bus.on("recovery:update", payload => {
+  console.log("Recovery summary", payload);
+});
+
+bus.emit("helix:focus", { pillar: 21 });</code></pre>
+      </section>
+
+      <section class="section" aria-labelledby="recovery-title">
+        <h2 id="recovery-title" class="section__title">Recovery Summary</h2>
+        <p class="section__content">Track the 33-spine / 21-pillar fusion state and public-purity filter here. Ledger-only interactions keep data sovereign; no external requests fire from this shell.</p>
+      </section>
+    </main>
+  </div>
+
+  <script type="module">
+    const root = document.body;
+    const acknowledgeButton = document.getElementById("gate-acknowledge");
+    const motionButton = document.getElementById("gate-motion");
+
+    function dismissGate() {
+      root.setAttribute("data-gate-state", "dismissed");
+    }
+
+    function lockMotion() {
+      root.setAttribute("data-motion", "still");
+      if (motionButton) {
+        motionButton.setAttribute("aria-disabled", "true");
+      }
+    }
+
+    if (acknowledgeButton) {
+      acknowledgeButton.addEventListener("click", () => {
+        dismissGate();
+        lockMotion();
+      });
+    }
+
+    lockMotion();
+  </script>
+</body>
+</html>

--- a/public/ui/primitives.css
+++ b/public/ui/primitives.css
@@ -1,0 +1,204 @@
+/*
+  primitives.css
+  Structural primitives for the cathedral hub two-panel shell.
+  ND-safe: static layout, calm gradients, enforced 44px touch targets.
+*/
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: var(--ui-space-5);
+  min-height: 100vh;
+  font-family: var(--ui-font-sans);
+  font-size: var(--ui-font-size-base);
+  line-height: 1.5;
+  background: radial-gradient(circle at top, rgba(66, 70, 112, 0.35), transparent 65%), var(--ui-color-bg-deep);
+  color: var(--ui-color-ink-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 960px) {
+  body {
+    padding: var(--ui-space-4);
+  }
+}
+
+.ui-shell {
+  width: min(1200px, 100%);
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(420px, 2fr);
+  gap: var(--ui-space-5);
+  background: linear-gradient(160deg, rgba(26, 26, 44, 0.95), rgba(12, 12, 20, 0.9));
+  border-radius: var(--ui-radius-m);
+  box-shadow: var(--ui-shadow-frame);
+  border: var(--ui-border-soft);
+  padding: var(--ui-space-5);
+}
+
+@media (max-width: 900px) {
+  .ui-shell {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  background: var(--ui-color-bg-panel);
+  border-radius: var(--ui-radius-s);
+  padding: var(--ui-space-5);
+  border: var(--ui-border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-space-4);
+}
+
+.panel--nav {
+  background: linear-gradient(180deg, rgba(32, 32, 56, 0.92), rgba(22, 22, 38, 0.95));
+}
+
+.panel h1,
+.panel h2,
+.panel h3 {
+  margin: 0;
+  font-family: var(--ui-font-sans);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: var(--ui-font-size-heading);
+}
+
+.panel h1 {
+  font-size: var(--ui-font-size-title);
+}
+
+.panel p {
+  margin: 0;
+  color: var(--ui-color-ink-muted);
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-space-2);
+}
+
+.nav-item {
+  display: block;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: var(--ui-space-touch);
+  padding: 0 var(--ui-space-3);
+  border-radius: var(--ui-radius-s);
+  color: var(--ui-color-ink-strong);
+  text-decoration: none;
+  background: rgba(122, 144, 210, 0.16);
+  border: var(--ui-border-soft);
+}
+
+.nav-link:focus-visible,
+.nav-link:hover {
+  outline: none;
+  border-color: rgba(123, 179, 240, 0.7);
+  box-shadow: 0 0 0 2px rgba(123, 179, 240, 0.35);
+}
+
+.motion-gate {
+  border: var(--ui-border-soft);
+  border-radius: var(--ui-radius-s);
+  padding: var(--ui-space-4);
+  background: rgba(12, 12, 24, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-space-3);
+}
+
+.motion-gate__title {
+  font-size: var(--ui-font-size-heading);
+}
+
+.motion-gate__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ui-space-3);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--ui-space-touch);
+  min-height: var(--ui-space-touch);
+  padding: 0 var(--ui-space-4);
+  border-radius: var(--ui-radius-s);
+  border: 1px solid rgba(123, 179, 240, 0.6);
+  background: rgba(123, 179, 240, 0.22);
+  color: var(--ui-color-ink-strong);
+  font-size: var(--ui-font-size-small);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.button:focus-visible,
+.button:hover {
+  outline: none;
+  border-color: rgba(160, 255, 161, 0.8);
+  box-shadow: 0 0 0 2px rgba(160, 255, 161, 0.35);
+}
+
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-space-3);
+}
+
+.section__title {
+  font-size: var(--ui-font-size-heading);
+}
+
+.section__content {
+  max-width: 70ch;
+  color: var(--ui-color-ink-muted);
+}
+
+.code-snippet {
+  font-family: var(--ui-font-mono);
+  background: rgba(18, 18, 28, 0.8);
+  border-radius: var(--ui-radius-s);
+  padding: var(--ui-space-3);
+  border: var(--ui-border-soft);
+  overflow-x: auto;
+}
+
+[data-motion="still"] .motion-enabled {
+  display: none;
+}
+
+[data-gate-state="dismissed"] .motion-gate {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001s !important;
+    transition-duration: 0.001s !important;
+  }
+}

--- a/public/ui/tokens.css
+++ b/public/ui/tokens.css
@@ -1,0 +1,62 @@
+/*
+  tokens.css
+  Kanso/Ma/Shibumi-inspired design tokens for the cathedral hub shell.
+  ND-safe choices: soft dusk palette, AA+ contrast, no animated colors.
+*/
+
+:root {
+  color-scheme: dark;
+
+  /* Core palette: layered geometry stays calm and legible. */
+  --ui-color-bg-deep: #0b0b12;
+  --ui-color-bg-panel: #151524;
+  --ui-color-bg-elevated: #1f1f33;
+  --ui-color-ink-strong: #f0f0ff;
+  --ui-color-ink-muted: #b6b6d3;
+  --ui-color-accent: #7bb3f0;
+  --ui-color-accent-soft: #4a90e2;
+  --ui-color-strand: #a0ffa1;
+
+  /* Border + shadow tokens maintain depth without motion. */
+  --ui-border-soft: 1px solid rgba(120, 128, 180, 0.35);
+  --ui-shadow-frame: 0 0 0 1px rgba(40, 44, 80, 0.6);
+
+  /* Spacing tokens respect Ma (intentional emptiness). */
+  --ui-space-1: 4px;
+  --ui-space-2: 8px;
+  --ui-space-3: 12px;
+  --ui-space-4: 16px;
+  --ui-space-5: 24px;
+  --ui-space-6: 32px;
+  --ui-space-touch: 44px; /* Minimum interactive target, AA+ friendly. */
+
+  /* Typography tokens keep layers quiet yet legible. */
+  --ui-font-sans: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --ui-font-mono: "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
+  --ui-font-size-base: 16px;
+  --ui-font-size-small: 14px;
+  --ui-font-size-title: 20px;
+  --ui-font-size-heading: 18px;
+
+  /* Radius + duration tokens (near-zero motion). */
+  --ui-radius-s: 8px;
+  --ui-radius-m: 16px;
+  --ui-motion-duration: 0.01s;
+  --ui-motion-ease: ease-out;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --ui-color-bg-deep: #f3f4f9;
+    --ui-color-bg-panel: #ffffff;
+    --ui-color-bg-elevated: #f7f8fc;
+    --ui-color-ink-strong: #1c1c2a;
+    --ui-color-ink-muted: #4a4a66;
+    --ui-color-accent: #4a90e2;
+    --ui-color-accent-soft: #7bb3f0;
+    --ui-color-strand: #2f8f52;
+    --ui-border-soft: 1px solid rgba(48, 52, 100, 0.18);
+    --ui-shadow-frame: 0 0 0 1px rgba(48, 52, 100, 0.24);
+  }
+}


### PR DESCRIPTION
## Summary
- add the shared global contract reminder at the repository root
- create ND-safe Kanso/Ma/Shibumi UI tokens, primitives, and hub shell HTML under public/ui
- introduce a lightweight TypeScript event bus targeting the cathedral-core websocket and add a Fly.io ignore list

## Testing
- npm test *(fails: package.json is not valid JSON in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d13c2576ac832897f298a8aef62ea2