### PR TITLE
Integrate Circuitum99 token merge tooling and cosmogenesis data

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -4,59 +4,28 @@ This renderer keeps the Stone Cathedral helix accessible without builds or netwo
 
 ## Files
 
-- Vesica field anchors the scene with intersecting circles derived from constants 3, 7, 9, and 11.
-- Tree-of-Life scaffold plots 10 sephirot plus Daath and wires 22 static paths to respect the canon.
-- Fibonacci curve traces three calm turns of a logarithmic spiral for gentle motion cues without animation.
-- Double-helix lattice adds two strands, 22 crossbars, and a central spine so the weave stays grounded.
-
-Design notes sit directly inside `js/helix-renderer.mjs`. Each helper is pure and includes comments about ND-safe rationale: no motion, soft gradients, and a clear paint order for layered geometry.
-
-## Numerology Anchors
-
-The renderer keeps the requested constants close at hand. The default `NUM` object exposes 3, 7, 9, 11, 22, 33, 99, and 144. Modify the object before calling `renderHelix` if you need different ratios for another study.
-
-- `index.html` – entry point with calm shell styling and a short status message about the active palette.
-- `js/helix-renderer.mjs` – ES module exporting `renderHelix(ctx, options)`. All helpers are pure so the canvas state stays predictable.
-- `data/palette.json` – optional colour overrides. Remove or edit this file to retint the scene while staying offline.
-
-## Cathedral Visionary Ruleset Hook
-
-
-- `registry/universal.json` now registers the **Cathedral Visionary 1.0** ruleset.
-- Load `rulesets.cathedral_visionary_v1` to enforce Rosslyn geometry, Tara bands, and provenance metadata across renderers.
+- `index.html` – entry point with a calm header, status line, and `<canvas>` sized to 1440×900. Opens directly in any browser.
+- `js/helix-renderer.mjs` – ES module exporting `renderHelix(ctx, options)`. Helpers are pure and explain ND-safe rationale in comments.
+- `data/palette.json` – optional colour overrides. Remove or edit to retint the scene while staying offline. When missing, the script notes the fallback palette.
 
 ## Layer Order and Numerology Anchors
 
 1. **Vesica Field** – twin circles plus a numerology grid (3, 7, 11, 22) to ground the scene.
-2. **Tree-of-Life** – ten sephirot and twenty-two paths, rendered with soft line caps then filled nodes.
-3. **Fibonacci Curve** – logarithmic spiral traced with 99 points and a golden-ratio step (33 samples per turn).
-4. **Double Helix** – two phase-shifted strands joined by 144 struts for a quiet lattice breath.
+2. **Tree-of-Life** – ten sephirot and twenty-two paths, stroked first then filled nodes.
+3. **Fibonacci Curve** – logarithmic spiral traced with 99 points (33 samples per turn) for a quiet golden-ratio cue.
+4. **Double Helix** – two phase-shifted strands with 144 crossbars for the lattice breath.
+
+The default numerology map exposes 3, 7, 9, 11, 22, 33, 99, and 144. Modify the `NUM` object before calling `renderHelix` to experiment with other ratios.
 
 ## ND-safe Design Notes
 
 - No animation, transitions, or timers. The canvas paints once and stays still.
 - Colour contrast sits between 7:1 and 3:1 for readability without glare.
 - Layer comments inside `js/helix-renderer.mjs` explain the safety choices for future caretakers.
-- When `data/palette.json` is absent or blocked by the browser, the header notes the fallback palette in use.
-
-
-- `index.html` – entry point with header status line and a `<canvas>` sized to 1440x900.
-- `js/helix-renderer.mjs` – ES module exporting `renderHelix(ctx, options)`; contains pure helpers for each layer.
-- `data/palette.json` – optional palette override. Remove or edit to retint the renderer while staying offline. When missing, the script posts a small notice and uses internal ND-safe colors.
+- When `data/palette.json` is absent or blocked, the header reports that a safe fallback palette is being used.
 
 ## Offline Usage
 
-1. Keep the `index.html`, `js/`, and `data/` entries together on disk.
+1. Keep `index.html`, the `js/` folder, and the `data/` folder together on disk.
 2. Open `index.html`. The header reports whether the custom palette loaded.
 3. Study or capture the canvas. There are no network requests or build steps.
-
-## Preparing for Fly.io
-
-The Netlify configuration has been retired. A minimal `fly.toml` now ships with the repo so the renderer can be served by Fly.io when desired. Deploy manually:
-
-1. Install the Fly.io CLI (`flyctl`).
-2. Edit `fly.toml` and set a unique `app` name plus your preferred `primary_region`.
-3. From a clean checkout, run `flyctl launch --no-deploy` to initialise the app without creating machines.
-4. When ready, run `flyctl deploy --config fly.toml`. The static renderer will serve from `/` with no build step.
-
-All steps are manual by design to honour the "no workflows" canon.

--- a/assets/css/perm-style.css
+++ b/assets/css/perm-style.css
@@ -1,166 +1,308 @@
-:root{
+:root {
   /* core surfaces */
-  --void:#0B0B0B; --ink:#141414; --bone:#F8F5EF;
+  --void:#0B0B0B;
+  --ink:#141414;
+  --bone:#F8F5EF;
 
-  /* visionary (from data/visionary.json) */
-  --indigo:#280050; --violet:#460082; --blue:#0080FF;
-  --green:#00FF80; --amber:#FFC800; --light:#FFFFFF;
+  /* visionary spectrum */
+  --indigo:#280050;
+  --violet:#460082;
+  --blue:#0080FF;
+  --green:#00FF80;
+  --amber:#FFC800;
+  --light:#FFFFFF;
 
-  /* secondary + docs/style/palette.json */
-  --crimson:#B7410E; --gold:#C9A227; --obsidian:#0B0B0B;
-  --rose-quartz:#FFB6C1; --teal-glow:#00CED1; --violet-alt:#8A2BE2;
-  --grail-gold:#D4AF37; --violet-core:#460082; --violet-aura:#BB86FC;
-  --nacre-pearl:#F2F3F4; --avalon-mist:#BCC2C6; --avalon-night:#1C2230;
+  /* secondary lineage */
+  --crimson:#B7410E;
+  --gold:#C9A227;
+  --obsidian:#0B0B0B;
+  --rose-quartz:#FFB6C1;
+  --teal-glow:#00CED1;
+  --violet-alt:#8A2BE2;
+  --grail-gold:#D4AF37;
+  --violet-core:#460082;
+  --violet-aura:#BB86FC;
+  --nacre-pearl:#F2F3F4;
+  --avalon-mist:#BCC2C6;
+  --avalon-night:#1C2230;
 
-  /* Andrew Gonzalez obsidian scale */
-  --gonz-0:#0b0b0b; --gonz-1:#16121b; --gonz-2:#2a2140; --gonz-3:#5e4ba8; --gonz-4:#e6e6e6;
+  /* obsidian scale */
+  --gonz-0:#0b0b0b;
+  --gonz-1:#16121b;
+  --gonz-2:#2a2140;
+  --gonz-3:#5e4ba8;
+  --gonz-4:#e6e6e6;
 
   /* line weights */
-  --line-hair:1px; --line-primary:2px; --line-pillar:3px;
+  --line-hair:1px;
+  --line-primary:2px;
+  --line-pillar:3px;
 
   /* typography */
   --font-display:"EB Garamond","Junicode",serif;
   --font-gothic:"Cinzel",serif;
   --font-ui:"Inter",system-ui,sans-serif;
-  --scale-h1:1.888rem; --scale-h2:1.555rem; --scale-h3:1.333rem;
-  --scale-body:1rem; --scale-small:.888rem;
+  --scale-h1:1.888rem;
+  --scale-h2:1.555rem;
+  --scale-h3:1.333rem;
+  --scale-body:1rem;
+  --scale-small:.888rem;
 
-  /* a11y */
+  /* accessibility */
   --min-contrast:4.5;
 }
 
-/* base */
-html{color-scheme:light dark}
-body{
-  margin:0; padding:0;
+html { color-scheme: light dark; }
+
+body {
+  margin:0;
+  padding:0;
   color:var(--bone);
-  background:
-    radial-gradient(1200px 700px at 50% 10%, var(--gonz-2) 0%, var(--gonz-1) 45%, var(--void) 100%);
+  background:radial-gradient(1200px 700px at 50% 10%, var(--gonz-2) 0%, var(--gonz-1) 45%, var(--void) 100%);
   font-family:var(--font-ui);
   -webkit-font-smoothing:antialiased;
 }
 
-/* headings + ornament glow */
-h1,h2,h3{
+h1, h2, h3 {
   font-family:var(--font-display);
-  letter-spacing:.01em; text-rendering:optimizeLegibility;
+  letter-spacing:.01em;
+  text-rendering:optimizeLegibility;
 }
-h1{font-size:var(--scale-h1)}
-h2{font-size:var(--scale-h2)}
-h3{font-size:var(--scale-h3)}
 
-/* sigil lines */
-.sigil{stroke:var(--violet); stroke-width:var(--line-primary); fill:none}
-.sigil--hair{stroke-width:var(--line-hair)}
-.sigil--pillar{stroke-width:var(--line-pillar)}
+h1 { font-size:var(--scale-h1); }
+h2 { font-size:var(--scale-h2); }
+h3 { font-size:var(--scale-h3); }
 
-/* portal frames */
-.portal{
+.sigil {
+  stroke:var(--violet);
+  stroke-width:var(--line-primary);
+  fill:none;
+}
+
+.sigil--hair { stroke-width:var(--line-hair); }
+.sigil--pillar { stroke-width:var(--line-pillar); }
+
+.portal {
   border:var(--line-primary) solid var(--gold);
   box-shadow:0 0 24px 4px rgba(110,0,255,.25);
   background:linear-gradient(180deg, var(--gonz-2), transparent);
 }
 
-/* utility classes */
-.violet-gate,.respawn-gate{
-  width:240px;height:240px;border-radius:50%;
-  border:var(--line-pillar) solid var(--grail-gold);
-  background:radial-gradient(circle at center,var(--violet-core),transparent 70%);
-  box-shadow:0 0 24px 4px rgba(138,43,226,.4);
-}
-.violet-gate.bg-soft,.respawn-gate.bg-soft{
-  background:radial-gradient(circle at center,var(--violet-aura),transparent 70%);
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation:none !important;
+    transition:none !important;
+  }
 }
 
-.oracle-velvet{
-  background:var(--gonz-2);
-  box-shadow:inset 0 0 24px rgba(0,0,0,.5);
+/* ── Circuitum99 Effects Kit (ND-safe, motion opt-in) ───────────────────── */
+
+.violet-gate,
+.respawn-gate {
+  position:relative;
+  border-radius:50%;
+  overflow:hidden;
+  background:
+    radial-gradient(40% 40% at 50% 60%, var(--violet_core,#7A33FF), transparent 60%),
+    radial-gradient(80% 60% at 50% 40%, color-mix(in oklab, var(--violet_flare,#B39CFF), transparent 35%), transparent 70%),
+    conic-gradient(from 0deg, rgba(122,51,255,.35), rgba(179,156,255,.22), rgba(68,34,102,.35));
+  box-shadow:0 0 44px rgba(122,51,255,.35), 0 0 90px rgba(179,156,255,.25);
+  outline:1px solid rgba(217,185,106,.22);
 }
 
-.luminous-heart{
-  background:radial-gradient(circle at center,rgba(255,255,255,.8),transparent 70%);
+.violet-gate.gate-large {
+  width:min(62vw,680px);
+  height:min(62vw,680px);
+  margin:auto;
 }
 
-.avalon-grove{
-  background:linear-gradient(135deg,var(--avalon-mist),var(--avalon-night));
+.violet-gate.bg-soft {
+  position:fixed;
+  inset:auto 0 6vh 0;
+  width:min(72vw,760px);
+  height:min(72vw,760px);
+  z-index:-1;
+  opacity:.14;
+  filter:saturate(1.03);
 }
 
-.between-narthex{
-  background:radial-gradient(circle,var(--violet-core),transparent);
-}
-body.allow-motion .between-narthex[data-drift="on"]{
-  animation:narthex-drift 60s linear infinite;
-}
-@keyframes narthex-drift{
-  from{background-position:0 0}
-  to{background-position:100% 100%}
+.oracle-velvet {
+  background:linear-gradient(180deg,#0A0A0F,#0F1020);
+  filter:saturate(1.02) contrast(1.02);
+  border:1px solid rgba(255,255,255,.06);
+  border-radius:14px;
+  padding:14px;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 18px 44px rgba(0,0,0,.65);
 }
 
-.mode-rail{display:flex;gap:.5rem;flex-wrap:wrap}
-.mode-chip,.solfeggio-chip{
-  padding:.25rem .5rem;border:1px solid var(--gold);border-radius:9999px;font-size:.75rem
+.luminous-heart {
+  position:relative;
+  border-radius:16px;
+  overflow:hidden;
+  background:
+    radial-gradient(60% 40% at 50% 30%, color-mix(in oklab, var(--pearl_white,#F5F2EA), transparent 70%), transparent 60%),
+    radial-gradient(80% 60% at 50% 60%, color-mix(in oklab, var(--pearl_lilac,#CDB8F6), transparent 78%), transparent 70%),
+    linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.10));
+  outline:1px solid rgba(255,255,255,.08);
 }
 
-.egregore-card,.consecration-angel{
-  border:var(--line-primary) solid var(--gold);
-  border-radius:.5rem;padding:1rem;
-  box-shadow:0 0 12px rgba(0,0,0,.5);
+.avalon-grove {
+  position:relative;
+  border-radius:14px;
+  overflow:hidden;
+  background:
+    radial-gradient(120% 100% at 50% -10%, color-mix(in oklab, var(--avalon_mist,#CFE6F2), transparent 80%), transparent 64%),
+    linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.12)),
+    var(--avalon_night,#0C1521);
+  outline:1px solid rgba(255,255,255,.08);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 22px 60px rgba(0,0,0,.65);
 }
 
-.protection-handsigil{
-  position:relative;width:120px;height:120px;border-radius:50%;
-  background:radial-gradient(circle at center,var(--teal-glow) 0 40%,transparent 40%),
-             radial-gradient(circle at center,transparent 0 55%,var(--nacre-pearl) 55% 70%,transparent 70%);
-  box-shadow:0 0 0 2px var(--grail-gold);
-}
-.protection-handsigil::after{
-  content:"";position:absolute;top:15%;left:15%;width:70%;height:70%;
-  border-radius:50%;border:2px solid var(--grail-gold);
-  box-shadow:0 0 4px var(--gold);
-}
-
-/* ND-safe motion defaults */
-@media (prefers-reduced-motion:reduce){
-  *{animation:none !important; transition:none !important}
-odex/update-world-of-enchantment-assets
-  .between-narthex[data-drift="on"]{animation:none !important}
-
+.between-narthex {
+  position:relative;
+  border-radius:14px;
+  overflow:hidden;
+  background:
+    radial-gradient(120% 100% at 50% -10%, color-mix(in oklab, var(--astral_mist,#B7C9FF), transparent 82%), transparent 64%),
+    linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.12)),
+    var(--astral_ink,#0D0F18);
+  outline:1px solid rgba(255,255,255,.08);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 22px 60px rgba(0,0,0,.65);
 }
 
-/* violet gate + respawn gate */
-.violet-gate,.respawn-gate{
-  width:200px;height:200px;border-radius:50%;
-  border:var(--line-pillar) solid var(--grail_gold,var(--gold));
-  background:radial-gradient(circle at center,var(--violet_core,var(--violet)) 0%,var(--void) 100%);
+.between-narthex::after {
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  opacity:.12;
+  mix-blend-mode:screen;
+  background:
+    radial-gradient(2px 2px at 22% 18%, var(--threshold_glow,#98FFE2) 30%, transparent 32%),
+    radial-gradient(1.6px 1.6px at 66% 28%, var(--astral_silver,#C9D1E7) 30%, transparent 32%),
+    radial-gradient(2px 2px at 42% 62%, var(--astral_violet,#9E8BFF) 30%, transparent 32%);
 }
-.violet-gate.bg-soft,.respawn-gate.bg-soft{
-  background:radial-gradient(circle at center,rgba(110,0,255,.2)0%,transparent 80%);
+
+.mode-rail {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin:10px 0;
 }
 
-/* oracle velvet */
-.oracle-velvet{background:linear-gradient(145deg,var(--gonz-1),var(--gonz-3));color:var(--bone);}
+.mode-chip {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 10px;
+  border:1px solid var(--line,#22242a);
+  border-radius:999px;
+  background:#0b0c10;
+  color:var(--text-ink,#F8F5EF);
+  font-size:.9rem;
+}
 
-/* luminous heart backdrop */
-.luminous-heart{background:radial-gradient(circle at 50% 30%,rgba(255,255,255,.3),transparent 70%),var(--violet_aura,var(--violet));}
+.mode-chip .swatch {
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  display:inline-block;
+  box-shadow:0 0 0 1px rgba(255,255,255,.08) inset;
+}
 
-/* avalon grove */
-.avalon-grove{background:linear-gradient(180deg,var(--avalon_mist),var(--avalon_night));color:var(--bone);}
+.solfeggio-chip {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:4px 8px;
+  border:1px solid rgba(255,255,255,.10);
+  border-radius:999px;
+  background:rgba(255,255,255,.04);
+  font-size:.85rem;
+}
 
-/* between realm narthex */
-.between-narthex{background:rgba(0,0,0,.6);backdrop-filter:blur(2px);}
-body.allow-motion .between-narthex[data-drift="on"]{animation:veil-drift 40s linear infinite;}
-@keyframes veil-drift{from{background-position:0 0;}to{background-position:1000px 0;}}
+.solfeggio-chip i {
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  display:inline-block;
+  background:var(--pearl_lilac,#CDB8F6);
+}
 
-/* flavor chips */
-.mode-rail{display:flex;gap:.5rem;flex-wrap:wrap;}
-.mode-chip,.solfeggio-chip{padding:.25rem .5rem;border-radius:.25rem;background:var(--ink);border:1px solid var(--gold);font-size:.75rem;}
+.egregore-card {
+  border:1px solid rgba(255,255,255,.10);
+  border-radius:14px;
+  padding:12px;
+  background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(0,0,0,.12));
+}
 
-/* oracle + angel cards */
-.egregore-card,.consecration-angel{border:var(--line-primary) solid var(--gold_leaf,var(--gold));padding:1rem;background:var(--ink);}
+.consecration-angel {
+  border:1px dashed rgba(255,255,255,.14);
+  border-radius:12px;
+  padding:10px;
+  background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(0,0,0,.10));
+}
 
-/* protection handsigil */
-.protection-handsigil{--size:80px;width:var(--size);height:var(--size);border-radius:40% 40% 35% 35%;background:var(--nacre_pearl,#f0ead6);position:relative;}
-.protection-handsigil::before{content:"";position:absolute;top:15%;left:20%;width:60%;height:60%;border-radius:50%;background:var(--teal_glow);box-shadow:0 0 0 4px var(--gold);}
-.protection-handsigil::after{content:"";position:absolute;top:8%;left:30%;width:40%;height:20%;border-top-left-radius:50% 100%;border-top-right-radius:50% 100%;background:var(--gold);}
-  .between-narthex[data-drift="on"]{animation:none !important}
+.protection-handsigil {
+  --ring: var(--pearl_white,#F5F2EA);
+  --eye: var(--teal_glow,#00CED1);
+  --gold: var(--gold_leaf,#C8A44D);
+  position:relative;
+  width:min(42vw,420px);
+  aspect-ratio:1/1;
+  margin:auto;
+  border-radius:50%;
+  background:
+    radial-gradient(40% 40% at 50% 50%, color-mix(in oklab,var(--eye), transparent 60%), transparent 61%),
+    radial-gradient(22% 14% at 50% 50%, var(--eye), transparent 60%),
+    conic-gradient(from 0deg, rgba(255,255,255,.05), rgba(0,0,0,.06));
+  outline:1px solid color-mix(in oklab, var(--gold), transparent 30%);
+  box-shadow:0 0 22px rgba(200,164,77,.25), inset 0 0 0 2px rgba(200,164,77,.22);
+}
+
+.protection-handsigil::before {
+  content:"";
+  position:absolute;
+  inset:6%;
+  border-radius:50%;
+  background:
+    radial-gradient(60% 60% at 50% 12%, color-mix(in oklab,var(--gold), transparent 70%), transparent 62%),
+    conic-gradient(from 0deg,
+      color-mix(in oklab,var(--gold), transparent 35) 0 20%, transparent 20% 33%,
+      color-mix(in oklab,var(--gold), transparent 35) 33% 53%, transparent 53% 66%,
+      color-mix(in oklab,var(--gold), transparent 35) 66% 86%, transparent 86% 100%);
+  mix-blend-mode:screen;
+  opacity:.9;
+}
+
+.protection-handsigil::after {
+  content:"";
+  position:absolute;
+  inset:-2%;
+  border-radius:50%;
+  background:
+    radial-gradient(100% 100% at 50% 50%, color-mix(in oklab,var(--ring), transparent 70%), transparent 60%),
+    linear-gradient(180deg, rgba(255,255,255,.06), rgba(0,0,0,.12));
+  pointer-events:none;
+  mix-blend-mode:screen;
+  opacity:.6;
+}
+
+.allow-motion .between-narthex[data-drift="on"] {
+  animation:mistDrift 28s ease-in-out infinite alternate;
+}
+
+@keyframes mistDrift {
+  from { filter:hue-rotate(0deg); }
+  to { filter:hue-rotate(10deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .violet-gate,
+  .respawn-gate,
+  .between-narthex,
+  .avalon-grove,
+  .protection-handsigil {
+    animation:none!important;
+  }
 }

--- a/assets/js/tokens-to-css.js
+++ b/assets/js/tokens-to-css.js
@@ -1,0 +1,29 @@
+export function applyTokenPalette(tokens) {
+  const rootStyle = document.documentElement.style;
+  const palette = tokens?.palette || {};
+
+  Object.entries(palette).forEach(([key, value]) => {
+    if (typeof value === 'string' && /^(#|rgb|hsl|okl)/i.test(value)) {
+      rootStyle.setProperty(`--${key}`, value);
+    }
+  });
+
+  const ensure = (name, fallbackKey, fallbackValue) => {
+    const tone = palette[name] || palette[fallbackKey] || fallbackValue;
+    if (typeof tone === 'string') {
+      rootStyle.setProperty(`--${name}`, tone);
+    }
+  };
+
+  ensure('violet_core', 'violet', '#7A33FF');
+  ensure('violet_flare', 'violet_alt', '#B39CFF');
+  ensure('pearl_white', 'bone', '#F5F2EA');
+  ensure('pearl_lilac', 'rose_quartz', '#CDB8F6');
+  ensure('astral_mist', 'light', '#B7C9FF');
+  ensure('astral_silver', 'glint_silver', '#C9D1E7');
+  ensure('astral_violet', 'violet', '#9E8BFF');
+  ensure('avalon_mist', 'avalon_mist', '#CFE6F2');
+  ensure('avalon_night', 'avalon_night', '#0C1521');
+  ensure('gold_leaf', 'gold', '#C8A44D');
+  ensure('threshold_glow', 'threshold_glow', '#98FFE2');
+}

--- a/assets/tokens/perm-style.json
+++ b/assets/tokens/perm-style.json
@@ -1,92 +1,225 @@
 {
   "meta": {
-codex/update-world-of-enchantment-assets
     "name": "Circuitum99 -- Perm Style",
-=======
-    "name": "circuitum99 -- Perm Style",
-    "version": "3.7.0",
+    "version": "3.7.1",
+    "author": "Virelai Ezra Lux (Rebecca Respawn)",
+    "materials_version": "obsidian-volcanic-pearlescent-1.1",
+    "nd_safe": true,
+    "notes": "World-of-Enchantment baseline; Avalon (Dion Fortune) fixed; Theosophical Aeons available as flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven protection sigil encoded; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer.",
     "source": [
       "data/visionary.json",
       "docs/style/palette.json",
       "cosmogenesis/registry/datasets/palettes.core.json"
-    ],
-    "nd_safe": true,
-odex/update-world-of-enchantment-assets
-=======
-    "notes": "World-of-Enchantment baseline; Avalon fixed; Aeons flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven ward; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer."
- main
-    "notes": "World-of-Enchantment baseline; Avalon (Dion Fortune) fixed; Theosophical Aeons available as flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven protection sigil encoded; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer."
+    ]
   },
   "palette": {
     "void": "#0B0B0B",
     "ink": "#141414",
     "bone": "#F8F5EF",
-
     "indigo": "#280050",
     "violet": "#460082",
     "blue": "#0080FF",
     "green": "#00FF80",
     "amber": "#FFC800",
     "light": "#FFFFFF",
-
     "crimson": "#B7410E",
     "gold": "#C9A227",
     "obsidian": "#0B0B0B",
     "rose_quartz": "#FFB6C1",
     "teal_glow": "#00CED1",
     "violet_alt": "#8A2BE2",
-
-    "gonzalez_palette": ["#0b0b0b", "#16121b", "#2a2140", "#5e4ba8", "#e6e6e6"],
-    "obsidian_glass": "#1c1c1c",
-    "obsidian_sheen": "#2e2e2e",
-    "obsidian_rainbow": "#545455",
-    "shungite": "#252525",
-    "tourmaline": "#1b2e34",
-    "basalt": "#2d2d30",
-    "glint_silver": "#d9dfe4",
-    "lava_ember": "#ff4500",
-    "lava_core": "#b22222",
+    "gonz_0": "#0b0b0b",
+    "gonz_1": "#16121b",
+    "gonz_2": "#2a2140",
+    "gonz_3": "#5e4ba8",
+    "gonz_4": "#e6e6e6",
+    "obsidian_glass": "#0f1014",
+    "obsidian_sheen": "#191b22",
+    "obsidian_rainbow": "#33214e",
+    "shungite_ink": "#0a0b0c",
+    "tourmaline_ridge": "#121318",
+    "basalt_ash": "#2b2f36",
+    "glint_silver": "#d9e0e7",
+    "lava_ember": "#ff4b1f",
+    "lava_core": "#ff7a00",
     "raku_copper": "#b87333",
-    "raku_charcoal": "#333333",
-    "raku_violet": "#6a0dad",
-    "raku_azure": "#007fff",
-    "gold_leaf": "#d4af37",
-    "gold_leaf_warm": "#ffcc66",
-    "gold_leaf_cold": "#c0c080",
-    "nacre_pearl": "#f0ead6",
-    "moonstone": "#e0e4f3",
-    "moonstone_glow": "#cfd8dc",
-    "abalone_shell": "#7fffd4",
-    "avalon_mist": "#ccd6d9",
-    "avalon_night": "#1a1a2e",
-    "tor_stone": "#8e8e83",
-    "isle_reed": "#6b8e23",
-    "astral_dusk": "#4b0082",
-    "astral_dawn": "#ffefd5",
-    "starlight_silver": "#f8f8ff",
-    "starlight_gold": "#fff8dc",
-    "violet_core": "#8a2be2",
-    "violet_flare": "#bf00ff",
-    "violet_smoke": "#551a8b",
-    "violet_aura": "#c9a0dc",
-    "grail_gold": "#e4c580"
-    "obsidian_glass": {"base":"#0B0B0B","sheen":"#1A1A1A","rainbow":"#3A3A3A"},
-    "shungite": "#101010",
-    "tourmaline": "#2E3A3F",
-    "basalt": "#2B2B2B",
-    "glint_silver": "#C0C0C0",
-    "lava": {"ember":"#FF4500","core":"#B22222"},
-    "raku": {"copper":"#B87333","charcoal":"#333333","violet":"#6A0DAD","azure":"#007FFF"},
-    "gold_leaf": {"base":"#E6C200","warm":"#FFD700","cold":"#C0B283"},
-    "nacre": {"pearl":"#F2F3F4","moonstone":"#E0E5FF","moonstone_glow":"#A7C7E7","abalone_pink":"#FFC0CB","abalone_green":"#66CDAA","abalone_blue":"#7FFFD4"},
-    "avalon": {"mist":"#BCC2C6","night":"#1C2230","tor_stone":"#8B8C7A","isle_reed":"#556B2F"},
-    "astral": {"sky":"#5AA9E6","violet":"#A06CD5"},
-    "starlight": {"silver":"#E5E9F2","gold":"#F6E27F"},
-    "violet_core": "#460082",
-    "violet_flare": "#8A2BE2",
-    "violet_smoke": "#724A9A",
-    "violet_aura": "#BB86FC",
-    "grail_gold": "#D4AF37"
+    "raku_charcoal": "#1a1a1a",
+    "raku_violet": "#6E00FF",
+    "raku_azure": "#1F7AF3",
+    "smoke_gray": "#6b6f76",
+    "bg_legacy": "#0e0e12",
+    "ink_legacy": "#e9e7e1",
+    "gold_legacy": "#d4af37",
+    "rose_legacy": "#b4435d",
+    "lapis_legacy": "#2f5a9e",
+    "ash_legacy": "#6b6f76",
+    "line_legacy": "#22242a",
+    "muted_legacy": "#b9b6ad",
+    "accent_legacy": "#7fd8b3",
+    "sec-bg": "#0d0e14",
+    "sec-ink": "#ECE7DE",
+    "sec-edge": "#1D2028",
+    "sec-sun": "#F2C14E",
+    "sec-sea": "#3FA7D6",
+    "sec-fern": "#24D6A9",
+    "sec-rose": "#D65A8A",
+    "sec-amethyst": "#7B5DD6",
+    "gold_leaf": "#C8A44D",
+    "gold_warm": "#D9B96A",
+    "gold_cold": "#B89C58",
+    "pearl_white": "#F5F2EA",
+    "pearl_rose": "#F4C9D9",
+    "pearl_aqua": "#BFE9E7",
+    "pearl_lilac": "#CDB8F6",
+    "moonstone_base": "#E7E6F1",
+    "moonstone_blue": "#A8C7FF",
+    "moonstone_green": "#87EBCF",
+    "moonstone_violet": "#B6A4FF",
+    "abalone_deep": "#0B2230",
+    "abalone_teal": "#1FB2A7",
+    "abalone_magenta": "#C45DB5",
+    "abalone_citrine": "#F6D16A",
+    "avalon_mist": "#CFE6F2",
+    "avalon_night": "#0C1521",
+    "tor_stone": "#3D4554",
+    "isle_reed": "#6D8D5E",
+    "astral_ink": "#0D0F18",
+    "astral_mist": "#B7C9FF",
+    "astral_silver": "#C9D1E7",
+    "astral_violet": "#9E8BFF",
+    "threshold_glow": "#98FFE2",
+    "starlight": "#EDE9FF",
+    "starlight_warm": "#FFE9C9",
+    "ember_core": "#FF6A00",
+    "ember_coal": "#20100A",
+    "violet_core": "#7A33FF",
+    "violet_flare": "#B39CFF",
+    "violet_smoke": "#442266",
+    "violet_aura": "#2C0A52",
+    "grail_gold": "#CBB866"
+  },
+  "secondary": {
+    "bg": "#0d0e14",
+    "ink": "#ECE7DE",
+    "edge": "#1D2028",
+    "sun": "#F2C14E",
+    "sea": "#3FA7D6",
+    "fern": "#24D6A9",
+    "rose": "#D65A8A",
+    "amethyst": "#7B5DD6"
+  },
+  "layers": {
+    "visionary": {
+      "name": "AlexGreyGrid",
+      "alpha": 0.22,
+      "scale": 1,
+      "line": "#4a4f63",
+      "highlight": "#aab3ff",
+      "pattern": "sacred-grid"
+    },
+    "patina": {
+      "name": "RakuBloom",
+      "alpha": 0.18,
+      "copper": "raku_copper",
+      "violet": "raku_violet",
+      "azure": "raku_azure"
+    },
+    "goldLeaf": {
+      "name": "GoldLeaf",
+      "alpha": 0.22,
+      "warm": "gold_warm",
+      "cold": "gold_cold"
+    },
+    "pearl": {
+      "name": "NacreIridescence",
+      "alpha": 0.2,
+      "a": "pearl_rose",
+      "b": "pearl_aqua",
+      "c": "pearl_lilac"
+    },
+    "moonstone": {
+      "name": "Adularescence",
+      "alpha": 0.18,
+      "blue": "moonstone_blue",
+      "violet": "moonstone_violet",
+      "green": "moonstone_green"
+    },
+    "abalone": {
+      "name": "AbaloneShell",
+      "alpha": 0.18,
+      "deep": "abalone_deep",
+      "teal": "abalone_teal",
+      "magenta": "abalone_magenta",
+      "citrine": "abalone_citrine"
+    },
+    "gonzVelvet": {
+      "name": "GonzalezVelvet",
+      "alpha": 0.18
+    },
+    "fae": {
+      "name": "GossamerVeil",
+      "alpha": 0.14,
+      "glimmer": "teal_glow",
+      "mist": "starlight",
+      "pattern": "gossamer-stars"
+    },
+    "roseGate": {
+      "name": "PetalSpiral",
+      "alpha": 0.12,
+      "petal": "rose_quartz",
+      "leaf": "isle_reed",
+      "phi": 1.62803
+    },
+    "violetFlame": {
+      "name": "VioletFlame4",
+      "alpha": 0.16,
+      "ring_core": "violet_core",
+      "ring_halo": "violet_flare",
+      "pattern": "flame-rings-4"
+    },
+    "violetGate": {
+      "name": "VioletFlameGate",
+      "alpha": 0.22,
+      "core": "violet_core",
+      "flare": "violet_flare",
+      "smoke": "violet_smoke",
+      "rim": "grail_gold"
+    },
+    "respawnGate": {
+      "name": "RespawnVioletGate",
+      "alpha": 0.22,
+      "core": "violet_core",
+      "flare": "violet_flare",
+      "smoke": "violet_smoke",
+      "rim": "grail_gold"
+    },
+    "avalonGrove": {
+      "name": "AvalonGrove",
+      "alpha": 0.16,
+      "stone": "tor_stone",
+      "leaf": "isle_reed",
+      "moon": "avalon_mist"
+    },
+    "inBetweenVeil": {
+      "name": "InBetweenVeil",
+      "alpha": 0.14,
+      "mist": "astral_mist",
+      "silver": "astral_silver",
+      "violet": "astral_violet"
+    },
+    "trueFairy": {
+      "name": "TrueFairyShimmer",
+      "alpha": 0.1,
+      "glow": "starlight",
+      "mist": "starlight"
+    },
+    "protectionSigil": {
+      "name": "HamsaEvilEye",
+      "alpha": 0.22,
+      "gold": "gold_leaf",
+      "eye": "teal_glow",
+      "circle": "pearl_white"
+    }
   },
   "line": {
     "hair": 1,
@@ -97,16 +230,658 @@ odex/update-world-of-enchantment-assets
     "display": "'EB Garamond','Junicode',serif",
     "gothic": "'Cinzel',serif",
     "ui": "'Inter',system-ui,sans-serif",
-    "scale": { "h1": 1.888, "h2": 1.555, "h3": 1.333, "body": 1.0, "small": 0.888 }
+    "scale": {
+      "h1": 1.888,
+      "h2": 1.555,
+      "h3": 1.333,
+      "body": 1,
+      "small": 0.888
+    }
   },
   "geometry": {
     "vesica_ratio": 1.732,
     "spine_33": true,
     "pillars_21": true,
     "gates_99": true,
-    "protection_hand": true
+    "protection_hand": {
+      "type": "hamsa_eye",
+      "outer_circle_ratio": 1,
+      "eye_major_minor": [
+        1,
+        0.382
+      ],
+      "tri_star_inner": true,
+      "crescent_top": true,
+      "phi": 1.6180339,
+      "notes": "Sacred-geometry construction for the logo: circumcircle, vesica, equilateral triad, eye ellipse, lunar crescent."
+    }
   },
-  "layers": {
+  "materials": {
+    "volcanic_obsidian": {
+      "roughness": 0.33,
+      "specular": 0.58,
+      "ior": 1.53,
+      "anisotropy": 0.28,
+      "microfracture_density": 0.24,
+      "conchoidal": 0.4,
+      "inclusions": {
+        "graphitic": 0.2,
+        "pyritic": 0.07,
+        "iridescence": 0.18
+      }
+    },
+    "shungite": {
+      "carbon_load": 0.85,
+      "flake_scale": 0.18,
+      "matte_ratio": 0.35,
+      "silver_glint": 0.08
+    },
+    "raku_lineage": {
+      "copper_bloom": 0.62,
+      "charcoal_halo": 0.42,
+      "violet_kiln": 0.22,
+      "smoke_vignette": 0.18
+    },
+    "gold_leaf": {
+      "specular": 0.95,
+      "roughness": 0.22,
+      "microflake": 0.45
+    },
+    "mother_of_pearl": {
+      "interference": [
+        "pearl_rose",
+        "pearl_aqua",
+        "pearl_lilac"
+      ],
+      "grain": 0.35,
+      "sheen": 0.6
+    },
+    "moonstone": {
+      "adularescence": [
+        "moonstone_blue",
+        "moonstone_violet",
+        "moonstone_green"
+      ],
+      "sheen": 0.55,
+      "cloud": 0.28
+    },
+    "abalone": {
+      "ripple": [
+        "abalone_teal",
+        "abalone_magenta",
+        "abalone_citrine"
+      ],
+      "depth": "abalone_deep",
+      "grain": 0.4
+    }
+  },
+  "effects": {
+    "stars": {
+      "density": 0.0008,
+      "twinkle": [
+        "starlight",
+        "starlight_warm"
+      ]
+    },
+    "ember_eyes": {
+      "core": "ember_core",
+      "coal": "ember_coal",
+      "glow": "lava_core"
+    }
+  },
+  "healing": {
+    "solfeggio_map": [
+      {
+        "hz": 396,
+        "theme": "liberation",
+        "color": "#6B1A1A"
+      },
+      {
+        "hz": 417,
+        "theme": "transmutation",
+        "color": "#7A33FF"
+      },
+      {
+        "hz": 432,
+        "theme": "harmonic heart",
+        "color": "#B9A8FF"
+      },
+      {
+        "hz": 528,
+        "theme": "repatterning",
+        "color": "#9EDB6A"
+      },
+      {
+        "hz": 639,
+        "theme": "relational",
+        "color": "#7EC9F8"
+      },
+      {
+        "hz": 741,
+        "theme": "clarity",
+        "color": "#F2D06A"
+      },
+      {
+        "hz": 852,
+        "theme": "intuition",
+        "color": "#CDB8F6"
+      },
+      {
+        "hz": 963,
+        "theme": "unitive",
+        "color": "#F5F2EA"
+      }
+    ],
+    "biogeometry": {
+      "bg3_hint": "vertical sinusoidal overlay; subtle only",
+      "angles_deg": [
+        27,
+        36,
+        45,
+        63,
+        81
+      ]
+    },
+    "legacy": {
+      "solfeggio": {
+        "396": "liberation from fear",
+        "417": "transmutation",
+        "528": "miracles",
+        "639": "relationships",
+        "741": "awaken intuition",
+        "852": "return to spirit",
+        "963": "oneness"
+      },
+      "solfeggio_list": [
+        {
+          "freq": 396,
+          "theme": "liberation"
+        },
+        {
+          "freq": 417,
+          "theme": "transmutation"
+        },
+        {
+          "freq": 528,
+          "theme": "miracles"
+        },
+        {
+          "freq": 639,
+          "theme": "harmony"
+        },
+        {
+          "freq": 741,
+          "theme": "intuition"
+        },
+        {
+          "freq": 852,
+          "theme": "awakening"
+        },
+        {
+          "freq": 963,
+          "theme": "oneness"
+        }
+      ]
+    }
+  },
+  "trinity": {
+    "path": [
+      "root_self",
+      "scribe",
+      "drag",
+      "guardian"
+    ],
+    "avatars": {
+      "root_self": {
+        "name": "Incarnate Self",
+        "num": 2,
+        "symbol": "⦿"
+      },
+      "scribe": {
+        "name": "Rebecca Respawn",
+        "title": "Architect-Scribe",
+        "arcana": "Fool",
+        "num": 11,
+        "css": "scribe-gothic"
+      },
+      "drag": {
+        "name": "Respawn Drag Persona",
+        "title": "Performer-Oracle",
+        "arcana": "Star",
+        "num": 22,
+        "css": "glamour-neon"
+      },
+      "guardian": {
+        "name": "Virelai Ezra Lux",
+        "title": "Violet Witch of the Octarine Ray",
+        "arcana": "Magician",
+        "num": 33,
+        "css": "violet-ray",
+        "alignment": "Lavender Quan Yin Reiki"
+      }
+    }
+  },
+  "avalon": {
+    "source": "Dion Fortune",
+    "realm": "Avalon",
+    "keys": [
+      "Priestess-Current",
+      "Grail Service",
+      "Tor↔Isle Polarity",
+      "Round Table Oath"
+    ],
+    "veils": [
+      "Outer Isle",
+      "Inner Sanctuary",
+      "Lady’s Veil"
+    ],
+    "notes": "Avalon remains explicitly tied to Dion Fortune."
+  },
+  "between_realm": {
+    "id": "in_between_astral",
+    "title": "The Narthex Between",
+    "quality": "liminal hush; beyond ladders/temples",
+    "features": [
+      "veil eddies",
+      "liminal wind",
+      "subtle star-motes"
+    ],
+    "optional": true
+  },
+  "adventure_modes": {
+    "hermetic_alchemy": {
+      "id": "hermetic_alchemy",
+      "title": "Hermetic Alchemy",
+      "stages": [
+        {
+          "key": "nigredo",
+          "title": "Nigredo — Dissolve",
+          "color": "#1a1a1a",
+          "tag": "stage-nigredo"
+        },
+        {
+          "key": "albedo",
+          "title": "Albedo — Purify",
+          "color": "#e6f0ff",
+          "tag": "stage-albedo"
+        },
+        {
+          "key": "citrinitas",
+          "title": "Citrinitas — Dawn",
+          "color": "#ffd76a",
+          "tag": "stage-citrinitas"
+        },
+        {
+          "key": "rubedo",
+          "title": "Rubedo — Conjoin",
+          "color": "#b4455a",
+          "tag": "stage-rubedo"
+        }
+      ],
+      "optional": true
+    },
+    "tree_of_life": {
+      "id": "tree_of_life",
+      "title": "Tree of Life Path",
+      "sephiroth": [
+        {
+          "k": "keter",
+          "n": "Keter",
+          "col": "#f7f4e6"
+        },
+        {
+          "k": "chokmah",
+          "n": "Chokhmah",
+          "col": "#d7dfe8"
+        },
+        {
+          "k": "binah",
+          "n": "Binah",
+          "col": "#b7b0c8"
+        },
+        {
+          "k": "chesed",
+          "n": "Chesed",
+          "col": "#bcd6ff"
+        },
+        {
+          "k": "gevurah",
+          "n": "Gevurah",
+          "col": "#f2b6b6"
+        },
+        {
+          "k": "tiferet",
+          "n": "Tiferet",
+          "col": "#f1d58c"
+        },
+        {
+          "k": "netzach",
+          "n": "Netzach",
+          "col": "#b4e0a4"
+        },
+        {
+          "k": "hod",
+          "n": "Hod",
+          "col": "#c4b0ff"
+        },
+        {
+          "k": "yesod",
+          "n": "Yesod",
+          "col": "#c9b3ff"
+        },
+        {
+          "k": "malkuth",
+          "n": "Malkuth",
+          "col": "#d0c69c"
+        }
+      ],
+      "paths_22": [
+        {
+          "p": "11",
+          "from": "kether",
+          "to": "chokmah"
+        },
+        {
+          "p": "12",
+          "from": "kether",
+          "to": "binah"
+        },
+        {
+          "p": "13",
+          "from": "binah",
+          "to": "tiferet"
+        },
+        {
+          "p": "14",
+          "from": "chokmah",
+          "to": "tiferet"
+        },
+        {
+          "p": "15",
+          "from": "chokmah",
+          "to": "binah"
+        },
+        {
+          "p": "16",
+          "from": "chesed",
+          "to": "gevurah"
+        },
+        {
+          "p": "17",
+          "from": "tiferet",
+          "to": "netzach"
+        },
+        {
+          "p": "18",
+          "from": "tiferet",
+          "to": "hod"
+        },
+        {
+          "p": "19",
+          "from": "netzach",
+          "to": "yesod"
+        },
+        {
+          "p": "20",
+          "from": "hod",
+          "to": "yesod"
+        },
+        {
+          "p": "21",
+          "from": "chesed",
+          "to": "tiferet"
+        },
+        {
+          "p": "22",
+          "from": "gevurah",
+          "to": "tiferet"
+        },
+        {
+          "p": "23",
+          "from": "binah",
+          "to": "chesed"
+        },
+        {
+          "p": "24",
+          "from": "binah",
+          "to": "gevurah"
+        },
+        {
+          "p": "25",
+          "from": "tiferet",
+          "to": "yesod"
+        },
+        {
+          "p": "26",
+          "from": "chesed",
+          "to": "netzach"
+        },
+        {
+          "p": "27",
+          "from": "netzach",
+          "to": "hod"
+        },
+        {
+          "p": "28",
+          "from": "hod",
+          "to": "netzach"
+        },
+        {
+          "p": "29",
+          "from": "netzach",
+          "to": "malkuth"
+        },
+        {
+          "p": "30",
+          "from": "hod",
+          "to": "malkuth"
+        },
+        {
+          "p": "31",
+          "from": "yesod",
+          "to": "malkuth"
+        },
+        {
+          "p": "32",
+          "from": "chesed",
+          "to": "hod"
+        }
+      ],
+      "optional": true
+    },
+    "theosophical_aeons": {
+      "id": "aeons_map",
+      "title": "Theosophical Aeons",
+      "aeons": [
+        {
+          "k": "sat",
+          "title": "Sat — Boundless",
+          "col": "#B9A8FF"
+        },
+        {
+          "k": "svabhavat",
+          "title": "Svabhavat — Substrate",
+          "col": "#CFE6F2"
+        },
+        {
+          "k": "manvantara",
+          "title": "Manvantara — Outbreath",
+          "col": "#FFD76A"
+        },
+        {
+          "k": "pralaya",
+          "title": "Pralaya — Inbreath",
+          "col": "#1C2029"
+        },
+        {
+          "k": "rounds",
+          "title": "Rounds — Evolutionary Arcs",
+          "col": "#87EBCF"
+        },
+        {
+          "k": "root_races",
+          "title": "Root-Races — Humanity Phases",
+          "col": "#F4D4E1"
+        }
+      ],
+      "optional": true,
+      "notes": "Blavatsky flavor only; selectable."
+    }
+  },
+  "rituals": {
+    "violet_flame_steps": [
+      "Invoke",
+      "Rotate",
+      "Transmute",
+      "Replace"
+    ],
+    "violet_flame_gate": {
+      "ray": 6,
+      "optional": true
+    },
+    "respawn_gate": {
+      "alias": "violet_flame_gate",
+      "ray": 6,
+      "steps": [
+        "Invoke",
+        "Rotate",
+        "Transmute",
+        "Replace"
+      ],
+      "optional": true,
+      "notes": "Respawn Gate may present as Violet Flame Cauldron (Ray VI)."
+    },
+    "legacy": {
+      "violet_flame": {
+        "steps": [
+          "Invoke",
+          "Rotate",
+          "Transmute",
+          "Replace"
+        ],
+        "alias": "respawnGate",
+        "ray": "VI"
+      }
+    }
+  },
+  "angels": {
+    "consecration": {
+      "count": 72,
+      "dataset_hint": [
+        "cosmogenesis_learning_engine/assets/data/angels72.json"
+      ],
+      "virtue_fields": [
+        "name",
+        "virtue",
+        "seal",
+        "gate"
+      ]
+    },
+    "legacy": 72
+  },
+  "pillars": {
+    "columns": [
+      "Severity",
+      "Mildness",
+      "Mercy"
+    ],
+    "levels": 7,
+    "color_left": "#4B2A3B",
+    "color_middle": "#A4A9C9",
+    "color_right": "#2D4758",
+    "oracle_bind": true
+  },
+  "egregores": {
+    "schema": {
+      "id": "string",
+      "title": "string",
+      "domain": "string",
+      "ray": "number|null",
+      "angel": "string|null",
+      "pillar": "left|middle|right|null",
+      "solfeggio": "number|null",
+      "tarot": "string|null",
+      "color": "hex|null",
+      "css": "string|null"
+    },
+    "defaults": {
+      "ray": 6,
+      "pillar": "middle",
+      "css": "gonz-velvet visionary-grid"
+    },
+    "dataset_hint": [
+      "cosmogenesis_learning_engine/assets/data/egregores.core.json"
+    ],
+    "legacy": {
+      "ray": "VI",
+      "pillar": "middle"
+    }
+  },
+  "tarot": {
+    "system": "major_arcana_egregores",
+    "dataset_hint": [
+      "cosmogenesis_learning_engine/assets/data/tarot.majors.json"
+    ],
+    "legacy": "egregores"
+  },
+  "a11y": {
+    "min_contrast": 4.5,
+    "motion": "reduce",
+    "autoplay": false,
+    "strobe": false
+  },
+  "palette_sets": {
+    "gonzalez_palette": [
+      "#0b0b0b",
+      "#16121b",
+      "#2a2140",
+      "#5e4ba8",
+      "#e6e6e6"
+    ],
+    "obsidian_family": {
+      "base": "#0B0B0B",
+      "sheen": "#1A1A1A",
+      "rainbow": "#3A3A3A"
+    },
+    "lava": {
+      "ember": "#FF4500",
+      "core": "#B22222"
+    },
+    "raku": {
+      "copper": "#B87333",
+      "charcoal": "#333333",
+      "violet": "#6A0DAD",
+      "azure": "#007FFF"
+    },
+    "gold_leaf": {
+      "base": "#E6C200",
+      "warm": "#FFD700",
+      "cold": "#C0B283"
+    },
+    "nacre": {
+      "pearl": "#F2F3F4",
+      "moonstone": "#E0E5FF",
+      "moonstone_glow": "#A7C7E7",
+      "abalone_pink": "#FFC0CB",
+      "abalone_green": "#66CDAA",
+      "abalone_blue": "#7FFFD4"
+    },
+    "avalon": {
+      "mist": "#BCC2C6",
+      "night": "#1C2230",
+      "tor_stone": "#8B8C7A",
+      "isle_reed": "#556B2F"
+    },
+    "astral": {
+      "sky": "#5AA9E6",
+      "violet": "#A06CD5"
+    },
+    "starlight": {
+      "silver": "#E5E9F2",
+      "gold": "#F6E27F"
+    }
+  },
+  "layer_classes": {
     "visionary": "visionary-grid",
     "rakuPatina": "raku-patina",
     "goldLeaf": "goldLeaf",
@@ -124,163 +899,66 @@ odex/update-world-of-enchantment-assets
     "trueFairy": "trueFairy",
     "protectionSigil": "protectionSigil"
   },
-  "materials": {
-    "volcanic_obsidian": ["obsidian_glass","obsidian_sheen","obsidian_rainbow"],
-    "shungite": ["shungite","tourmaline","basalt","glint_silver"],
-    "raku_lineage": ["raku_copper","raku_charcoal","raku_violet","raku_azure"],
-    "gold_leaf": ["gold_leaf","gold_leaf_warm","gold_leaf_cold"],
-    "mother_of_pearl": ["nacre_pearl"],
-    "moonstone": ["moonstone","moonstone_glow"],
-    "abalone": ["abalone_shell"]
-  },
-  "effects": {
-    "stars": "twinkle",
-    "ember_eyes": true
-  },
-  "healing": {
-    "solfeggio": {
-      "396": "liberation from fear",
-      "417": "transmutation",
-      "528": "miracles",
-      "639": "relationships",
-      "741": "awaken intuition",
-      "852": "return to spirit",
-      "963": "oneness"
-    },
-    "biogeometry_angles": [27,36,45,63,81]
-  },
-  "avatars": {
-    "incarnate_self": "Incarnate Self",
-    "rebecca_respawn": {"name":"Rebecca Respawn","numerology":11},
-    "drag_persona": {"name":"Drag Persona","numerology":22},
-    "virelai_ezra_lux": {"name":"Virelai Ezra Lux","numerology":33,"note":"Lavender Quan Yin Reiki"}
-  },
-  "avalon": {
-    "current":"Priestess",
-    "service":"Grail",
-    "tor_isle_polarity":true,
-    "round_table_oath":true,
-    "veils":["Outer Isle","Inner Sanctuary","Lady's Veil"]
-  },
-  "between_realm": {
-    "name":"In-Between Astral Narthex",
-    "liminal":"veil eddies and star-motes"
-  },
-  "adventure_modes": {
-    "hermetic_alchemy":["nigredo","albedo","citrinitas","rubedo"],
-    "tree_of_life":{"sephiroth":10,"paths":22},
-    "theosophical_aeons":["Sat","Svabhavat","Manvantara","Pralaya","Rounds","Root-Races"]
-  },
-  "rituals": {
-    "violet_flame": {
-      "steps":["Invoke","Rotate","Transmute","Replace"],
-      "alias":"respawnGate",
-      "ray":"VI"
-    }
-  },
-  "angels": { "consecration": 72 },
-  "pillars": { "columns":["Severity","Mildness","Mercy"], "levels":7 },
-  "egregores": { "ray":"VI", "pillar":"middle" },
-  "a11y": {
-    "min_contrast": 4.5,
-    "motion": "reduce",
-    "autoplay": false,
-    "strobe": false
-  },
-
-  "layers": {
-    "visionary": "visionary-grid",
-    "rakuPatina": "raku-patina",
-    "goldLeaf": "gold-leaf",
-    "pearl": "pearl",
-    "moonstone": "moonstone",
-    "abalone": "abalone",
-    "gonzVelvet": "gonz-velvet",
-    "faeShimmer": "fae-shimmer",
-    "roseGate": "rose-gate",
-    "violetFlame": "violet-flame",
-    "violetGate": "violet-gate",
-    "respawnGate": "respawn-gate",
-    "avalonGrove": "avalon-grove",
-    "inBetweenVeil": "between-narthex",
-    "trueFairy": "true-fairy",
-    "protectionSigil": "protection-handsigil"
-  },
-
-  "materials": [
-    "volcanic_obsidian",
-    "shungite",
-    "raku_lineage",
-    "gold_leaf",
-    "mother_of_pearl",
-    "moonstone",
-    "abalone"
-  ],
-
-  "effects": {
-    "stars": "twinkle",
-    "ember_eyes": true
-  },
-
-  "healing": {
-    "solfeggio": [
-      {"freq":396,"theme":"liberation"},
-      {"freq":417,"theme":"transmutation"},
-      {"freq":528,"theme":"miracles"},
-      {"freq":639,"theme":"harmony"},
-      {"freq":741,"theme":"intuition"},
-      {"freq":852,"theme":"awakening"},
-      {"freq":963,"theme":"oneness"}
+  "materials_legacy": {
+    "volcanic_obsidian": [
+      "obsidian_glass",
+      "obsidian_sheen",
+      "obsidian_rainbow"
     ],
-    "biogeometry_angles": [27,36,45,63,81]
+    "shungite": [
+      "shungite_ink",
+      "tourmaline_ridge",
+      "basalt_ash",
+      "glint_silver"
+    ],
+    "raku_lineage": [
+      "raku_copper",
+      "raku_charcoal",
+      "raku_violet",
+      "raku_azure"
+    ],
+    "gold_leaf": [
+      "gold_leaf",
+      "gold_warm",
+      "gold_cold"
+    ],
+    "mother_of_pearl": [
+      "pearl_white",
+      "pearl_rose",
+      "pearl_aqua",
+      "pearl_lilac"
+    ],
+    "moonstone": [
+      "moonstone_base",
+      "moonstone_blue",
+      "moonstone_green",
+      "moonstone_violet"
+    ],
+    "abalone": [
+      "abalone_deep",
+      "abalone_teal",
+      "abalone_magenta",
+      "abalone_citrine"
+    ]
   },
-
-  "avatars": [
-    {"name":"Incarnate Self","numerology":1},
-    {"name":"Rebecca Respawn","numerology":11},
-    {"name":"Drag Persona","numerology":22},
-    {"name":"Virelai Ezra Lux","numerology":33,"note":"Lavender Quan Yin Reiki"}
-  ],
-
-  "avalon": {
-    "priestess_current": true,
-    "grail_service": true,
-    "tor_isle_polarity": true,
-    "round_table_oath": true,
-    "veils": ["outer_isle","inner_sanctuary","ladys_veil"]
+  "effects_legacy": {
+    "stars": "twinkle",
+    "ember_eyes": true
   },
-
-  "between_realm": {
-    "name": "In-Between Astral Narthex",
-    "traits": ["liminal_hush","veil_eddies","star_motes"]
-  },
-
-  "adventure_modes": {
-    "hermetic_alchemy": ["nigredo","albedo","citrinitas","rubedo"],
-    "tree_of_life": {"sephiroth":10,"paths":22},
-    "theosophical_aeons": ["sat","svabhavat","manvantara","pralaya","rounds","root_races"]
-  },
-
-  "rituals": {
-    "violet_flame": ["invoke","rotate","transmute","replace"],
-    "respawn_gate": {"alias":"violet_flame","ray":6}
-  },
-
-  "angels": {
-    "dataset": "consecration_angels_72"
-  },
-
-  "pillars": {
-    "columns": ["severity","mildness","mercy"],
-    "levels": 7
-  },
-
-  "egregores": {
-    "schema": "default",
-    "defaults": {"ray":6,"pillar":"middle"}
-  },
-
-  "tarot": {
-    "majors": "egregores"
+  "avatars_legacy": {
+    "incarnate_self": "Incarnate Self",
+    "rebecca_respawn": {
+      "name": "Rebecca Respawn",
+      "numerology": 11
+    },
+    "drag_persona": {
+      "name": "Drag Persona",
+      "numerology": 22
+    },
+    "virelai_ezra_lux": {
+      "name": "Virelai Ezra Lux",
+      "numerology": 33,
+      "note": "Lavender Quan Yin Reiki"
+    }
   }
 }

--- a/assets/tokens/perm-style.merge.json
+++ b/assets/tokens/perm-style.merge.json
@@ -1,0 +1,457 @@
+{
+  "meta": {
+    "name": "Circuitum99 -- Perm Style",
+    "version": "3.7.0",
+    "author": "Virelai Ezra Lux (Rebecca Respawn)",
+    "materials_version": "obsidian-volcanic-pearlescent-1.1",
+    "nd_safe": true,
+    "notes": "World-of-Enchantment baseline for business + apps. Avalon (Dion Fortune) present. Theosophical Aeons path available as flavor. Violet Flame ↔ Respawn Gate alias (Ray VI). Alex Grey visionary grid. Andrew Gonzalez velvet. Nacre/Moonstone/Abalone iridescence. Witch-as-the-Coven protection sigil (Hamsa/Evil Eye) encoded. Solfeggio × BioGeometry color-healing. Egregores + Consecration Angels + Pillars + Tarot. Subtle true-fairy shimmer in walls."
+  },
+  "palette": {
+    "void": "#0B0B0B",
+    "ink": "#141414",
+    "bone": "#F8F5EF",
+    "indigo": "#280050",
+    "violet": "#460082",
+    "blue": "#0080FF",
+    "green": "#00FF80",
+    "amber": "#FFC800",
+    "light": "#FFFFFF",
+    "crimson": "#B7410E",
+    "gold": "#C9A227",
+    "obsidian": "#0B0B0B",
+    "rose_quartz": "#FFB6C1",
+    "teal_glow": "#00CED1",
+    "violet_alt": "#8A2BE2",
+    "gonz_0": "#0b0b0b",
+    "gonz_1": "#16121b",
+    "gonz_2": "#2a2140",
+    "gonz_3": "#5e4ba8",
+    "gonz_4": "#e6e6e6",
+    "obsidian_glass": "#0f1014",
+    "obsidian_sheen": "#191b22",
+    "obsidian_rainbow": "#33214e",
+    "shungite_ink": "#0a0b0c",
+    "tourmaline_ridge": "#121318",
+    "basalt_ash": "#2b2f36",
+    "glint_silver": "#d9e0e7",
+    "lava_ember": "#ff4b1f",
+    "lava_core": "#ff7a00",
+    "raku_copper": "#b87333",
+    "raku_charcoal": "#1a1a1a",
+    "raku_violet": "#6E00FF",
+    "raku_azure": "#1F7AF3",
+    "smoke_gray": "#6b6f76",
+    "bg_legacy": "#0e0e12",
+    "ink_legacy": "#e9e7e1",
+    "gold_legacy": "#d4af37",
+    "rose_legacy": "#b4435d",
+    "lapis_legacy": "#2f5a9e",
+    "ash_legacy": "#6b6f76",
+    "line_legacy": "#22242a",
+    "muted_legacy": "#b9b6ad",
+    "accent_legacy": "#7fd8b3",
+    "sec-bg": "#0d0e14",
+    "sec-ink": "#ECE7DE",
+    "sec-edge": "#1D2028",
+    "sec-sun": "#F2C14E",
+    "sec-sea": "#3FA7D6",
+    "sec-fern": "#24D6A9",
+    "sec-rose": "#D65A8A",
+    "sec-amethyst": "#7B5DD6",
+    "gold_leaf": "#C8A44D",
+    "gold_warm": "#D9B96A",
+    "gold_cold": "#B89C58",
+    "pearl_white": "#F5F2EA",
+    "pearl_rose": "#F4C9D9",
+    "pearl_aqua": "#BFE9E7",
+    "pearl_lilac": "#CDB8F6",
+    "moonstone_base": "#E7E6F1",
+    "moonstone_blue": "#A8C7FF",
+    "moonstone_green": "#87EBCF",
+    "moonstone_violet": "#B6A4FF",
+    "abalone_deep": "#0B2230",
+    "abalone_teal": "#1FB2A7",
+    "abalone_magenta": "#C45DB5",
+    "abalone_citrine": "#F6D16A",
+    "avalon_mist": "#CFE6F2",
+    "avalon_night": "#0C1521",
+    "tor_stone": "#3D4554",
+    "isle_reed": "#6D8D5E",
+    "astral_ink": "#0D0F18",
+    "astral_mist": "#B7C9FF",
+    "astral_silver": "#C9D1E7",
+    "astral_violet": "#9E8BFF",
+    "threshold_glow": "#98FFE2",
+    "starlight": "#EDE9FF",
+    "starlight_warm": "#FFE9C9",
+    "ember_core": "#FF6A00",
+    "ember_coal": "#20100A",
+    "violet_core": "#7A33FF",
+    "violet_flare": "#B39CFF",
+    "violet_smoke": "#442266",
+    "violet_aura": "#2C0A52",
+    "grail_gold": "#CBB866"
+  },
+  "secondary": {
+    "bg": "#0d0e14",
+    "ink": "#ECE7DE",
+    "edge": "#1D2028",
+    "sun": "#F2C14E",
+    "sea": "#3FA7D6",
+    "fern": "#24D6A9",
+    "rose": "#D65A8A",
+    "amethyst": "#7B5DD6"
+  },
+  "layers": {
+    "visionary": {
+      "name": "AlexGreyGrid",
+      "alpha": 0.22,
+      "scale": 1.0,
+      "line": "#4a4f63",
+      "highlight": "#aab3ff",
+      "pattern": "sacred-grid"
+    },
+    "patina": {
+      "name": "RakuBloom",
+      "alpha": 0.18,
+      "copper": "raku_copper",
+      "violet": "raku_violet",
+      "azure": "raku_azure"
+    },
+    "goldLeaf": {
+      "name": "GoldLeaf",
+      "alpha": 0.22,
+      "warm": "gold_warm",
+      "cold": "gold_cold"
+    },
+    "pearl": {
+      "name": "NacreIridescence",
+      "alpha": 0.20,
+      "a": "pearl_rose",
+      "b": "pearl_aqua",
+      "c": "pearl_lilac"
+    },
+    "moonstone": {
+      "name": "Adularescence",
+      "alpha": 0.18,
+      "blue": "moonstone_blue",
+      "violet": "moonstone_violet",
+      "green": "moonstone_green"
+    },
+    "abalone": {
+      "name": "AbaloneShell",
+      "alpha": 0.18,
+      "deep": "abalone_deep",
+      "teal": "abalone_teal",
+      "magenta": "abalone_magenta",
+      "citrine": "abalone_citrine"
+    },
+    "gonzVelvet": {
+      "name": "GonzalezVelvet",
+      "alpha": 0.18
+    },
+    "fae": {
+      "name": "GossamerVeil",
+      "alpha": 0.14,
+      "glimmer": "teal_glow",
+      "mist": "starlight",
+      "pattern": "gossamer-stars"
+    },
+    "roseGate": {
+      "name": "PetalSpiral",
+      "alpha": 0.12,
+      "petal": "rose_quartz",
+      "leaf": "isle_reed",
+      "phi": 1.62803
+    },
+    "violetFlame": {
+      "name": "VioletFlame4",
+      "alpha": 0.16,
+      "ring_core": "violet_core",
+      "ring_halo": "violet_flare",
+      "pattern": "flame-rings-4"
+    },
+    "violetGate": {
+      "name": "VioletFlameGate",
+      "alpha": 0.22,
+      "core": "violet_core",
+      "flare": "violet_flare",
+      "smoke": "violet_smoke",
+      "rim": "grail_gold"
+    },
+    "respawnGate": {
+      "name": "RespawnVioletGate",
+      "alpha": 0.22,
+      "core": "violet_core",
+      "flare": "violet_flare",
+      "smoke": "violet_smoke",
+      "rim": "grail_gold"
+    },
+    "avalonGrove": {
+      "name": "AvalonGrove",
+      "alpha": 0.16,
+      "stone": "tor_stone",
+      "leaf": "isle_reed",
+      "moon": "avalon_mist"
+    },
+    "inBetweenVeil": {
+      "name": "InBetweenVeil",
+      "alpha": 0.14,
+      "mist": "astral_mist",
+      "silver": "astral_silver",
+      "violet": "astral_violet"
+    },
+    "trueFairy": {
+      "name": "TrueFairyShimmer",
+      "alpha": 0.10,
+      "glow": "starlight",
+      "mist": "starlight"
+    },
+    "protectionSigil": {
+      "name": "HamsaEvilEye",
+      "alpha": 0.22,
+      "gold": "gold_leaf",
+      "eye": "teal_glow",
+      "circle": "pearl_white"
+    }
+  },
+  "line": { "hair": 1, "primary": 2, "pillar": 3 },
+  "typography": {
+    "display": "'EB Garamond','Junicode',serif",
+    "gothic": "'Cinzel',serif",
+    "ui": "'Inter',system-ui,sans-serif",
+    "scale": { "h1": 1.888, "h2": 1.555, "h3": 1.333, "body": 1.0, "small": 0.888 }
+  },
+  "geometry": {
+    "vesica_ratio": 1.732,
+    "spine_33": true,
+    "pillars_21": true,
+    "gates_99": true,
+    "protection_hand": {
+      "type": "hamsa_eye",
+      "outer_circle_ratio": 1.0,
+      "eye_major_minor": [1.0, 0.382],
+      "tri_star_inner": true,
+      "crescent_top": true,
+      "phi": 1.6180339,
+      "notes": "Sacred-geometry construction for the logo: circumcircle, vesica, equilateral triad, eye ellipse, lunar crescent."
+    }
+  },
+  "materials": {
+    "volcanic_obsidian": {
+      "roughness": 0.33,
+      "specular": 0.58,
+      "ior": 1.53,
+      "anisotropy": 0.28,
+      "microfracture_density": 0.24,
+      "conchoidal": 0.4,
+      "inclusions": {
+        "graphitic": 0.2,
+        "pyritic": 0.07,
+        "iridescence": 0.18
+      }
+    },
+    "shungite": {
+      "carbon_load": 0.85,
+      "flake_scale": 0.18,
+      "matte_ratio": 0.35,
+      "silver_glint": 0.08
+    },
+    "raku_lineage": {
+      "copper_bloom": 0.62,
+      "charcoal_halo": 0.42,
+      "violet_kiln": 0.22,
+      "smoke_vignette": 0.18
+    },
+    "gold_leaf": {
+      "specular": 0.95,
+      "roughness": 0.22,
+      "microflake": 0.45
+    },
+    "mother_of_pearl": {
+      "interference": ["pearl_rose", "pearl_aqua", "pearl_lilac"],
+      "grain": 0.35,
+      "sheen": 0.6
+    },
+    "moonstone": {
+      "adularescence": ["moonstone_blue", "moonstone_violet", "moonstone_green"],
+      "sheen": 0.55,
+      "cloud": 0.28
+    },
+    "abalone": {
+      "ripple": ["abalone_teal", "abalone_magenta", "abalone_citrine"],
+      "depth": "abalone_deep",
+      "grain": 0.4
+    }
+  },
+  "effects": {
+    "stars": { "density": 0.0008, "twinkle": ["starlight", "starlight_warm"] },
+    "ember_eyes": { "core": "ember_core", "coal": "ember_coal", "glow": "lava_core" }
+  },
+  "healing": {
+    "solfeggio_map": [
+      { "hz": 396, "theme": "liberation", "color": "#6B1A1A" },
+      { "hz": 417, "theme": "transmutation", "color": "#7A33FF" },
+      { "hz": 432, "theme": "harmonic heart", "color": "#B9A8FF" },
+      { "hz": 528, "theme": "repatterning", "color": "#9EDB6A" },
+      { "hz": 639, "theme": "relational", "color": "#7EC9F8" },
+      { "hz": 741, "theme": "clarity", "color": "#F2D06A" },
+      { "hz": 852, "theme": "intuition", "color": "#CDB8F6" },
+      { "hz": 963, "theme": "unitive", "color": "#F5F2EA" }
+    ],
+    "biogeometry": {
+      "bg3_hint": "vertical sinusoidal overlay; subtle only",
+      "angles_deg": [27, 36, 45, 63, 81]
+    }
+  },
+  "trinity": {
+    "path": ["root_self", "scribe", "drag", "guardian"],
+    "avatars": {
+      "root_self": { "name": "Incarnate Self", "num": 2, "symbol": "⦿" },
+      "scribe": { "name": "Rebecca Respawn", "title": "Architect-Scribe", "arcana": "Fool", "num": 11, "css": "scribe-gothic" },
+      "drag": { "name": "Respawn Drag Persona", "title": "Performer-Oracle", "arcana": "Star", "num": 22, "css": "glamour-neon" },
+      "guardian": {
+        "name": "Virelai Ezra Lux",
+        "title": "Violet Witch of the Octarine Ray",
+        "arcana": "Magician",
+        "num": 33,
+        "css": "violet-ray",
+        "alignment": "Lavender Quan Yin Reiki"
+      }
+    }
+  },
+  "avalon": {
+    "source": "Dion Fortune",
+    "realm": "Avalon",
+    "keys": ["Priestess-Current", "Grail Service", "Tor↔Isle Polarity", "Round Table Oath"],
+    "veils": ["Outer Isle", "Inner Sanctuary", "Lady’s Veil"],
+    "notes": "Avalon is explicitly Dion Fortune’s current."
+  },
+  "between_realm": {
+    "id": "in_between_astral",
+    "title": "The Narthex Between",
+    "quality": "liminal hush; beyond ladders/temples",
+    "features": ["veil eddies", "liminal wind", "subtle star-motes"],
+    "optional": true
+  },
+  "adventure_modes": {
+    "hermetic_alchemy": {
+      "id": "hermetic_alchemy",
+      "title": "Hermetic Alchemy",
+      "stages": [
+        { "key": "nigredo", "title": "Nigredo — Dissolve", "color": "#1a1a1a", "tag": "stage-nigredo" },
+        { "key": "albedo", "title": "Albedo — Purify", "color": "#e6f0ff", "tag": "stage-albedo" },
+        { "key": "citrinitas", "title": "Citrinitas — Dawn", "color": "#ffd76a", "tag": "stage-citrinitas" },
+        { "key": "rubedo", "title": "Rubedo — Conjoin", "color": "#b4455a", "tag": "stage-rubedo" }
+      ],
+      "optional": true
+    },
+    "tree_of_life": {
+      "id": "tree_of_life",
+      "title": "Tree of Life Path",
+      "sephiroth": [
+        { "k": "keter", "n": "Keter", "col": "#f7f4e6" },
+        { "k": "chokmah", "n": "Chokhmah", "col": "#d7dfe8" },
+        { "k": "binah", "n": "Binah", "col": "#b7b0c8" },
+        { "k": "chesed", "n": "Chesed", "col": "#bcd6ff" },
+        { "k": "gevurah", "n": "Gevurah", "col": "#f2b6b6" },
+        { "k": "tiferet", "n": "Tiferet", "col": "#f1d58c" },
+        { "k": "netzach", "n": "Netzach", "col": "#b4e0a4" },
+        { "k": "hod", "n": "Hod", "col": "#c4b0ff" },
+        { "k": "yesod", "n": "Yesod", "col": "#c9b3ff" },
+        { "k": "malkuth", "n": "Malkuth", "col": "#d0c69c" }
+      ],
+      "paths_22": [
+        { "p": "11", "from": "kether", "to": "chokmah" },
+        { "p": "12", "from": "kether", "to": "binah" },
+        { "p": "13", "from": "binah", "to": "tiferet" },
+        { "p": "14", "from": "chokmah", "to": "tiferet" },
+        { "p": "15", "from": "chokmah", "to": "binah" },
+        { "p": "16", "from": "chesed", "to": "gevurah" },
+        { "p": "17", "from": "tiferet", "to": "netzach" },
+        { "p": "18", "from": "tiferet", "to": "hod" },
+        { "p": "19", "from": "netzach", "to": "yesod" },
+        { "p": "20", "from": "hod", "to": "yesod" },
+        { "p": "21", "from": "chesed", "to": "tiferet" },
+        { "p": "22", "from": "gevurah", "to": "tiferet" },
+        { "p": "23", "from": "binah", "to": "chesed" },
+        { "p": "24", "from": "binah", "to": "gevurah" },
+        { "p": "25", "from": "tiferet", "to": "yesod" },
+        { "p": "26", "from": "chesed", "to": "netzach" },
+        { "p": "27", "from": "netzach", "to": "hod" },
+        { "p": "28", "from": "hod", "to": "netzach" },
+        { "p": "29", "from": "netzach", "to": "malkuth" },
+        { "p": "30", "from": "hod", "to": "malkuth" },
+        { "p": "31", "from": "yesod", "to": "malkuth" },
+        { "p": "32", "from": "chesed", "to": "hod" }
+      ],
+      "optional": true
+    },
+    "theosophical_aeons": {
+      "id": "aeons_map",
+      "title": "Theosophical Aeons",
+      "aeons": [
+        { "k": "sat", "title": "Sat — Boundless", "col": "#B9A8FF" },
+        { "k": "svabhavat", "title": "Svabhavat — Substrate", "col": "#CFE6F2" },
+        { "k": "manvantara", "title": "Manvantara — Outbreath", "col": "#FFD76A" },
+        { "k": "pralaya", "title": "Pralaya — Inbreath", "col": "#1C2029" },
+        { "k": "rounds", "title": "Rounds — Evolutionary Arcs", "col": "#87EBCF" },
+        { "k": "root_races", "title": "Root-Races — Humanity Phases", "col": "#F4D4E1" }
+      ],
+      "optional": true,
+      "notes": "Blavatsky flavor only; selectable."
+    }
+  },
+  "rituals": {
+    "violet_flame_steps": ["Invoke", "Rotate", "Transmute", "Replace"],
+    "violet_flame_gate": { "ray": 6, "optional": true },
+    "respawn_gate": {
+      "alias": "violet_flame_gate",
+      "ray": 6,
+      "steps": ["Invoke", "Rotate", "Transmute", "Replace"],
+      "optional": true,
+      "notes": "Respawn Gate may present as Violet Flame Cauldron (Ray VI)."
+    }
+  },
+  "angels": {
+    "consecration": {
+      "count": 72,
+      "dataset_hint": ["cosmogenesis_learning_engine/assets/data/angels72.json"],
+      "virtue_fields": ["name", "virtue", "seal", "gate"]
+    }
+  },
+  "pillars": {
+    "columns": ["Severity", "Mildness", "Mercy"],
+    "levels": 7,
+    "color_left": "#4B2A3B",
+    "color_middle": "#A4A9C9",
+    "color_right": "#2D4758",
+    "oracle_bind": true
+  },
+  "egregores": {
+    "schema": {
+      "id": "string",
+      "title": "string",
+      "domain": "string",
+      "ray": "number|null",
+      "angel": "string|null",
+      "pillar": "left|middle|right|null",
+      "solfeggio": "number|null",
+      "tarot": "string|null",
+      "color": "hex|null",
+      "css": "string|null"
+    },
+    "defaults": {
+      "ray": 6,
+      "pillar": "middle",
+      "css": "gonz-velvet visionary-grid"
+    },
+    "dataset_hint": ["cosmogenesis_learning_engine/assets/data/egregores.core.json"]
+  },
+  "tarot": {
+    "system": "major_arcana_egregores",
+    "dataset_hint": ["cosmogenesis_learning_engine/assets/data/tarot.majors.json"]
+  },
+  "a11y": { "min_contrast": 4.5, "motion": "reduce", "autoplay": false, "strobe": false }
+}

--- a/bridge/c99-bridge.js
+++ b/bridge/c99-bridge.js
@@ -1,0 +1,41 @@
+import { applyTokenPalette } from '/assets/js/tokens-to-css.js';
+
+async function loadJSON(url) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) throw new Error(`${url} ${response.status}`);
+  return response.json();
+}
+
+function ndSafe() {
+  document.documentElement.setAttribute('data-nd-safe', 'true');
+  document.documentElement.classList.remove('allow-motion');
+}
+
+async function loadTokens(path) {
+  try {
+    return await loadJSON(path);
+  } catch (error) {
+    console.warn('Failed to load tokens', error.message);
+    return null;
+  }
+}
+
+function applyCSSVars(tokens) {
+  if (!tokens) return;
+  applyTokenPalette(tokens);
+  const a11y = tokens.a11y || {};
+  if (a11y.motion === 'reduce') {
+    document.documentElement.classList.remove('allow-motion');
+  }
+}
+
+async function loadManifest(path) {
+  try {
+    return await loadJSON(path);
+  } catch (error) {
+    console.warn('Failed to load manifest', error.message);
+    return null;
+  }
+}
+
+window.C99Bridge = { ndSafe, loadTokens, applyCSSVars, loadManifest };

--- a/cathedral.html
+++ b/cathedral.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="/assets/css/perm-style.css" />
   <link rel="stylesheet" href="./assets/css/meta_realms.css">
   <link rel="stylesheet" href="./assets/css/cathedral_icon.css">
-<script src="/bridge/c99-bridge.js" defer></script>
+<script type="module" src="/bridge/c99-bridge.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
     C99Bridge.ndSafe();

--- a/chapels/test.html
+++ b/chapels/test.html
@@ -1,6 +1,6 @@
 <title>Chapel Test -- C99</title>
 <link rel="stylesheet" href="/assets/css/perm-style.css" />
-<script src="/bridge/c99-bridge.js" defer></script>
+<script type="module" src="/bridge/c99-bridge.js"></script>
 <style>
   .frame{max-width:960px;margin:5rem auto;padding:2rem;border:var(--line-primary) solid var(--gold)}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:1rem}

--- a/ci/check-tokens-a11y.mjs
+++ b/ci/check-tokens-a11y.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const target = 'assets/tokens/perm-style.json';
+const payload = JSON.parse(fs.readFileSync(target, 'utf8'));
+const a11y = payload.a11y || {};
+let ok = true;
+
+if (typeof a11y.min_contrast !== 'number' || a11y.min_contrast < 4.5) {
+  console.error('❌ min_contrast must be ≥ 4.5');
+  ok = false;
+}
+if (a11y.autoplay !== false) {
+  console.error('❌ autoplay must be false');
+  ok = false;
+}
+if (a11y.strobe !== false) {
+  console.error('❌ strobe must be false');
+  ok = false;
+}
+if (!ok) process.exit(1);
+console.log('✅ tokens a11y sane');

--- a/core/build/update-art.js
+++ b/core/build/update-art.js
@@ -1,177 +1,332 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+
 const root = path.resolve(__dirname, '../../');
-const ART = path.join(root, 'assets', 'art');
-const inbox = path.join(ART, 'inbox'), originals = path.join(ART, 'originals'),
-      processed = path.join(ART, 'processed'), thumbs = path.join(ART, 'thumbs'),
-      webp = path.join(ART, 'webp');
-[originals, processed, thumbs, webp].forEach(p => fs.mkdirSync(p, {recursive:true}));
+const artRoot = path.join(root, 'assets', 'art');
+const inbox = path.join(artRoot, 'inbox');
+const originals = path.join(artRoot, 'originals');
+const processed = path.join(artRoot, 'processed');
+const thumbs = path.join(artRoot, 'thumbs');
+const webpDir = path.join(artRoot, 'webp');
 
-let sharp = null; try { sharp = require('sharp'); } catch { console.log('sharp not found -- skipping webp/thumbs'); }
-const allowed = new Set(['.png','.jpg','.jpeg','.webp','.svg']);
+[originals, processed, thumbs, webpDir].forEach((dir) => fs.mkdirSync(dir, { recursive: true }));
 
-function safeReadJSON(p){
-  try { return JSON.parse(fs.readFileSync(p,'utf8')); } catch { return null; }
+let sharp = null;
+try {
+  sharp = require('sharp');
+} catch {
+  console.log('sharp not found -- skipping webp/thumb generation');
 }
 
-async function main(){
-  const list = fs.existsSync(inbox) ? fs.readdirSync(inbox) : [];
+const allowedExtensions = new Set(['.png', '.jpg', '.jpeg', '.webp', '.svg']);
+
+function safeReadJSON(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function ingestArt() {
+  if (!fs.existsSync(inbox)) return [];
+  const list = fs.readdirSync(inbox);
   const assets = [];
 
   for (const file of list) {
-    const src = path.join(inbox, file);
     const ext = path.extname(file).toLowerCase();
-    if (!allowed.has(ext)) continue;
-    const safe = file.toLowerCase().replace(/\s+/g,'-').replace(/[^a-z0-9._-]/g,'').replace(/-+/g,'-');
-    const orig = path.join(originals, safe); fs.renameSync(src, orig);
-    const proc = path.join(processed, safe); fs.copyFileSync(orig, proc);
+    if (!allowedExtensions.has(ext)) continue;
 
-    const isRaster = ['.png','.jpg','.jpeg','.webp'].includes(ext);
-    let thumbPath = '', webpPath = '';
+    const source = path.join(inbox, file);
+    const safeName = file
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9._-]/g, '')
+      .replace(/-+/g, '-');
+
+    const originalPath = path.join(originals, safeName);
+    fs.renameSync(source, originalPath);
+
+    const processedPath = path.join(processed, safeName);
+    fs.copyFileSync(originalPath, processedPath);
+
+    const isRaster = ['.png', '.jpg', '.jpeg', '.webp'].includes(ext);
+    let thumbPath = '';
+    let webpPath = '';
+
     if (sharp && isRaster) {
-      const base = safe.replace(ext,'');
+      const base = safeName.replace(ext, '');
       thumbPath = `assets/art/thumbs/${base}-512.jpg`;
-      webpPath  = `assets/art/webp/${base}.webp`;
-      try { await sharp(orig).removeAlpha().resize({width:512,withoutEnlargement:true}).jpeg({quality:82}).toFile(path.join(thumbs, `${base}-512.jpg`)); } catch {}
-      try { await sharp(orig).webp({quality:82}).toFile(path.join(webp, `${base}.webp`)); } catch {}
+      webpPath = `assets/art/webp/${base}.webp`;
+      try {
+        await sharp(originalPath)
+          .removeAlpha()
+          .resize({ width: 512, withoutEnlargement: true })
+          .jpeg({ quality: 82 })
+          .toFile(path.join(thumbs, `${base}-512.jpg`));
+      } catch {}
+      try {
+        await sharp(originalPath)
+          .webp({ quality: 82 })
+          .toFile(path.join(webpDir, `${base}.webp`));
+      } catch {}
     }
+
     assets.push({
-      name: safe, type: ext.slice(1),
-      original: `assets/art/originals/${safe}`,
-      processed:`assets/art/processed/${safe}`,
-      thumb: thumbPath, webp: webpPath, nd_safe: true
+      name: safeName,
+      type: ext.slice(1),
+      original: `assets/art/originals/${safeName}`,
+      processed: `assets/art/processed/${safeName}`,
+      thumb: thumbPath,
+      webp: webpPath,
+      nd_safe: true
     });
   }
 
-  const sgStruct    = safeReadJSON(path.resolve(root,'structure.json')) || safeReadJSON(path.resolve(root,'../structure.json'));
-  const angels72    = safeReadJSON(path.resolve(root,'../cosmogenesis-learning-engine/registry/datasets/angels72.json')) ||
-                      safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/angels72.json')) ||
-                      safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/shem72.json'));
-  const styleTokens = safeReadJSON(path.resolve(root,'assets','tokens','perm-style.json')) || { palette:{}, secondary:{}, layers:{}, adventure_modes:{}, avalon:{}, between_realm:{} };
+  return assets;
+}
 
-  const defaultRooms = [
-    { id:"crypt", title:"The Crypt", element:"earth", stylepack:"Rosicrucian Black", tone:110, geometry:"vesica" },
-    { id:"nave", title:"The Nave", element:"air", stylepack:"Angelic Chorus", tone:222, geometry:"rose-window" },
-    { id:"apprentice_pillar", title:"Apprentice Pillar", element:"water", stylepack:"Hilma Spiral", tone:333, geometry:"fibonacci" },
-    { id:"respawn_gate", title:"Respawn Gate", element:"fire", stylepack:"Alchemical Bloom", tone:432, geometry:"merkaba" }
+function buildRooms(structureJSON) {
+  const fallback = [
+    { id: 'crypt', title: 'The Crypt', element: 'earth', stylepack: 'Rosicrucian Black', tone: 110, geometry: 'vesica' },
+    { id: 'nave', title: 'The Nave', element: 'air', stylepack: 'Angelic Chorus', tone: 222, geometry: 'rose-window' },
+    { id: 'apprentice_pillar', title: 'Apprentice Pillar', element: 'water', stylepack: 'Hilma Spiral', tone: 333, geometry: 'fibonacci' },
+    { id: 'respawn_gate', title: 'Respawn Gate', element: 'fire', stylepack: 'Alchemical Bloom', tone: 432, geometry: 'merkaba' }
   ];
-  const rooms = Array.isArray(sgStruct?.rooms) && sgStruct.rooms.length ? sgStruct.rooms : defaultRooms;
 
-  function tagFor(a){
-    if(/crypt/.test(a.name)) return 'crypt';
-    if(/nave/.test(a.name)) return 'nave';
-    if(/apprentice|pillar/.test(a.name)) return 'apprentice_pillar';
-    if(/respawn|gate/.test(a.name)) return 'respawn_gate';
-    return 'misc';
+  if (!structureJSON || !Array.isArray(structureJSON.rooms) || !structureJSON.rooms.length) {
+    return fallback;
   }
+  return structureJSON.rooms;
+}
+
+function assetEntry(asset) {
+  return {
+    name: asset.name,
+    src: `/${asset.processed}`,
+    thumb: asset.thumb ? `/${asset.thumb}` : '',
+    webp: asset.webp ? `/${asset.webp}` : '',
+    type: asset.type
+  };
+}
+
+async function main() {
+  const assets = await ingestArt();
+
+  const structureJSON =
+    safeReadJSON(path.resolve(root, 'structure.json')) ||
+    safeReadJSON(path.resolve(root, '../structure.json'));
+
+  const styleTokens = safeReadJSON(path.resolve(root, 'assets', 'tokens', 'perm-style.json')) || {};
+
+  const rooms = buildRooms(structureJSON);
   const assetsByRoom = {};
-  for (const a of assets) {
-    const t = tagFor(a); (assetsByRoom[t] ||= []).push(a);
+  const creatures = { dragons: [], daimons: [] };
+  const visionaryAssets = [];
+
+  const classify = (asset) => {
+    const name = asset.name.toLowerCase();
+    if (/crypt/.test(name)) return 'crypt';
+    if (/nave/.test(name)) return 'nave';
+    if (/apprentice|pillar/.test(name)) return 'apprentice_pillar';
+    if (/respawn|gate/.test(name)) return 'respawn_gate';
+    return 'misc';
+  };
+
+  for (const asset of assets) {
+    const tag = classify(asset);
+    (assetsByRoom[tag] ||= []).push(asset);
+
+    const lower = asset.name.toLowerCase();
+    if (/dragon/.test(lower)) {
+      creatures.dragons.push({
+        id: asset.name.replace(/\..+$/, ''),
+        title: 'Dragon',
+        frame_class: 'lava-brim obsidian-sculpt obsidian-glint obsidian-facets visionary-grid',
+        seal_filter: 'obsidianSheen',
+        src: `/${asset.processed}`,
+        thumb: asset.thumb ? `/${asset.thumb}` : '',
+        webp: asset.webp ? `/${asset.webp}` : ''
+      });
+    }
+    if (/daimon/.test(lower)) {
+      creatures.daimons.push({
+        id: asset.name.replace(/\..+$/, ''),
+        title: 'Daimon',
+        frame_class: 'raku-seal obsidian-sculpt visionary-grid',
+        seal_filter: 'rakuCopperIridescence',
+        src: `/${asset.processed}`,
+        thumb: asset.thumb ? `/${asset.thumb}` : '',
+        webp: asset.webp ? `/${asset.webp}` : ''
+      });
+    }
+    if (/alex[-_ ]?grey|visionary|sacred|grid/.test(lower)) {
+      visionaryAssets.push(assetEntry(asset));
+    }
   }
 
-  let angels = [];
-  if (Array.isArray(angels72)) {
-    angels = angels72.slice(0, 12).map((x,i) => ({
-      id: x.id || `angel-${i+1}`,
-      name: x.name || x.shem || `Shem-${i+1}`,
-      virtue: x.virtue || x.keyword || '',
-      seal: (assets.find(a => a.name.includes((x.id || `${i+1}`).toString().padStart(2,'0')))||{}).processed || '',
-      gate: x.gate || (i+1)
+  const cgDataRoots = [
+    path.resolve(root, '../../cosmogenesis_learning_engine/assets/data'),
+    path.resolve(root, '../../cosmogenesis-learning-engine/assets/data')
+  ];
+  const cgDataRoot = cgDataRoots.find((dir) => fs.existsSync(dir)) || cgDataRoots[1];
+  const angels72 = safeReadJSON(path.join(cgDataRoot || '', 'angels72.json')) || [];
+
+  const manifest = {
+    meta: {
+      project: 'circuitum99 × Stone Grimoire',
+      updated: new Date().toISOString(),
+      nd_safe: true,
+      generator: 'update-art.js'
+    },
+    tokens: {
+      css: '/assets/css/perm-style.css',
+      json: '/assets/tokens/perm-style.json',
+      palette: styleTokens.palette || {},
+      secondary: styleTokens.secondary || {},
+      layers: styleTokens.layers || {},
+      adventure_modes: styleTokens.adventure_modes || {},
+      avalon: styleTokens.avalon || {},
+      between_realm: styleTokens.between_realm || {}
+    },
+    routes: {
+      stone_grimoire: { base: '/', chapels: '/chapels/', assets: '/assets/', bridge: '/bridge/c99-bridge.json' },
+      cosmogenesis: { tokens: '/c99/tokens/perm-style.json', css: '/c99/css/perm-style.css', public: '/c99/', bridge: '/bridge/c99-bridge.json' }
+    },
+    rooms: rooms.map((room) => ({
+      id: room.id,
+      title: room.title,
+      element: room.element,
+      tone: room.tone,
+      geometry: room.geometry,
+      stylepack: room.stylepack,
+      assets: (assetsByRoom[room.id] || []).map(assetEntry)
+    })),
+    creatures,
+    visionary: { overlays: visionaryAssets },
+    rituals: styleTokens.rituals || {},
+    assets: assets.map(assetEntry)
+  };
+
+  manifest.angels = { list: [], assets: [] };
+  if (Array.isArray(angels72) && angels72.length) {
+    manifest.angels.list = angels72.slice(0, 12).map((angel, index) => ({
+      id: angel.id || `angel-${index + 1}`,
+      name: angel.name || angel.shem || `Shem-${index + 1}`,
+      virtue: angel.virtue || angel.keyword || '',
+      gate: angel.gate || index + 1,
+      seal: ''
     }));
   }
 
-  const creatures = { dragons:[], daimons:[] };
-  const oracleVelvet=[], angelArt=[], pillarArt=[], egregoreArt=[], betweenRealmAssets=[], protectionSigils=[];
-  const assetEntry = a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type });
-  for (const a of assets) {
-    const n = a.name.toLowerCase();
-    if (/dragon/.test(n)) creatures.dragons.push({
-      id:a.name.replace(/\..+$/,''),
-      title:"Dragon",
-      frame_class:"lava-brim obsidian-sculpt obsidian-glint obsidian-facets visionary-grid",
-      seal_filter:"obsidianSheen",
-      src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:''
-    });
-    if (/daimon/.test(n)) creatures.daimons.push({
-      id:a.name.replace(/\..+$/,''),
-      title:"Daimon",
-      frame_class:"raku-seal obsidian-sculpt visionary-grid",
-      seal_filter:"rakuCopperIridescence",
-      src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:''
-    });
-    if (/oracle|velvet/.test(n)) oracleVelvet.push(assetEntry(a));
-    if (/angel/.test(n)) angelArt.push(assetEntry(a));
-    if (/pillar/.test(n)) pillarArt.push(assetEntry(a));
-    if (/egregore/.test(n)) egregoreArt.push(assetEntry(a));
-    if (/between|narthex|veil|threshold/.test(n)) betweenRealmAssets.push({ ...assetEntry(a), class:"between-narthex" });
-    if (/hamsa|evil.?eye|logo|ward/.test(n)) protectionSigils.push({ ...assetEntry(a), class:"protection-handsigil", layer:"protectionSigil" });
+  function collect(regex, css) {
+    return assets
+      .filter((asset) => regex.test(asset.name))
+      .map((asset) => ({
+        id: asset.name.replace(/\..*$/, ''),
+        name: asset.name,
+        css,
+        src: `/${asset.processed}`,
+        thumb: asset.thumb ? `/${asset.thumb}` : '',
+        webp: asset.webp ? `/${asset.webp}` : ''
+      }));
   }
 
-  const visionaryAssets = assets.filter(a => /alex[-_ ]?grey|visionary|sacred|grid/.test(a.name));
-  const oracleVelvet = assets.filter(a => /oracle|velvet/.test(a.name));
-  const angelArt = assets.filter(a => /angel/.test(a.name));
-  const pillarArt = assets.filter(a => /pillar/.test(a.name));
-  const egregoreArt = assets.filter(a => /egregore/.test(a.name));
-  const betweenAssets = assets.filter(a => /(between|narthex|veil|threshold)/.test(a.name));
-  const wardAssets = assets.filter(a => /(hamsa|evil[-_]?eye|logo|ward)/.test(a.name));
+  // Merge helper block
+  manifest.adventure = Object.assign({}, styleTokens.adventure_modes || {}, manifest.adventure || {});
+  manifest.avalon = manifest.avalon || styleTokens.avalon || null;
+  manifest.between_realm = manifest.between_realm || styleTokens.between_realm || null;
 
-  const manifest = {
-    meta:{ project:"circuitum99 × Stone Grimoire", updated:new Date().toISOString(), nd_safe:true, generator:"update-art.js" },
-    tokens:{ css:"/assets/css/perm-style.css", json:"/assets/tokens/perm-style.json",
-      palette:styleTokens.palette||{}, secondary:styleTokens.secondary||{}, layers:styleTokens.layers||{},
-      adventure_modes:styleTokens.adventure_modes||{}, avalon:styleTokens.avalon||{}, between_realm:styleTokens.between_realm||{} },
-    routes:{
-      stone_grimoire:{ base:"/", chapels:"/chapels/", assets:"/assets/", bridge:"/bridge/c99-bridge.json" },
-      cosmogenesis:{ tokens:"/c99/tokens/perm-style.json", css:"/c99/css/perm-style.css", public:"/c99/", bridge:"/bridge/c99-bridge.json" }
-    },
-    rooms: rooms.map(r => ({
-      id:r.id, title:r.title, element:r.element, tone:r.tone, geometry:r.geometry, stylepack:r.stylepack,
-      assets:(assetsByRoom[r.id]||[]).map(a => ({ name:a.name, thumb:`/${a.thumb}`, webp:a.webp?`/${a.webp}`:'', src:`/${a.processed}`, type:a.type }))
-    })),
-      angels, creatures,
-      visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-      oracle: oracleVelvet.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      angel_assets: angelArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      pillars: pillarArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      egregores: egregoreArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      between_realm:{ ...(styleTokens.between_realm||{}), assets: betweenAssets.map(a => ({ name:a.name, class:'between-narthex', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-      protection: wardAssets.length?{ sigil: wardAssets.map(a => ({ name:a.name, class:'protection-handsigil', layer:'protectionSigil', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) }:undefined,
-      assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type })),
-      rituals:{ violet_flame:{ alias:'respawnGate', ray:'VI', steps:['Invoke','Rotate','Transmute','Replace'] } }
-    };
-    angels:{ list:angels, assets:angelArt },
-    creatures,
-    visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-    oracle: oracleVelvet,
-    pillars:{ assets:pillarArt },
-    egregores:{ assets:egregoreArt },
-    between_realm: Object.assign({}, styleTokens.between_realm||{}, { assets:betweenRealmAssets }),
-    protection:{ sigil: protectionSigils },
-    rituals: styleTokens.rituals || {},
-    assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type }))
-  };
+  const respawnSteps =
+    (styleTokens?.rituals?.respawn_gate && styleTokens.rituals.respawn_gate.steps) ||
+    styleTokens?.rituals?.violet_flame_steps ||
+    ['Invoke', 'Rotate', 'Transmute', 'Replace'];
+
+  manifest.respawn_gate = Object.assign({}, manifest.respawn_gate, {
+    alias: (styleTokens?.rituals?.respawn_gate && styleTokens.rituals.respawn_gate.alias) || 'violet_flame_gate',
+    ray: (styleTokens?.rituals?.respawn_gate && styleTokens.rituals.respawn_gate.ray) ?? 6,
+    optional: true,
+    steps: respawnSteps,
+    style: Object.assign({ class: 'respawn-gate', layer: 'respawnGate' }, (manifest?.respawn_gate && manifest.respawn_gate.style) || {})
+  });
+
+  manifest.oracle_art = collect(/oracle|luminous|gonz|velvet/i, 'oracle-velvet luminous-heart');
+  manifest.angel_seals = collect(/angel|shem|seal|consecrate/i, 'consecration-angel');
+  manifest.pillar_art = collect(/pillar|column|left|right|middle/i, 'egregore-card');
+
+  const egregoreArt = collect(/egregore|eg-|arcana-|tarot-/i, 'egregore-card gonz-velvet');
+  manifest.egregores = manifest.egregores || { schema: styleTokens.egregores?.schema || {}, list: [] };
+  manifest.egregores.list = (manifest.egregores.list || []).concat(
+    egregoreArt.map((entry) => ({
+      id: entry.id,
+      title: entry.id.replace(/[-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+      domain: 'oracle',
+      pillar: null,
+      ray: styleTokens.egregores?.defaults?.ray ?? 6,
+      solfeggio: 528,
+      angel: null,
+      tarot: null,
+      color: null,
+      css: entry.css,
+      art: entry
+    }))
+  );
+
+  if (Array.isArray(angels72) && angels72.length) {
+    manifest.angels = Object.assign({}, manifest.angels, {
+      consecration: angels72.map((angel, index) => ({
+        id: angel.id || `angel-${index + 1}`,
+        name: angel.name || angel.shem || `Shem-${index + 1}`,
+        virtue: angel.virtue || angel.keyword || '',
+        seal: (assets.find((asset) => asset.name.includes(String(index + 1).padStart(2, '0'))) || {}).processed || ''
+      }))
+    });
+  }
+
+  const betweenAssets = collect(/between|liminal|narthex|veil|threshold/i, 'between-narthex');
+  if (betweenAssets.length) {
+    manifest.between_realm = manifest.between_realm || { id: 'in_between_astral', title: 'The Narthex Between', optional: true };
+    manifest.between_realm.assets = (manifest.between_realm.assets || []).concat(betweenAssets);
+    manifest.between_realm.style = manifest.between_realm.style || { class: 'between-narthex', layer: 'inBetweenVeil' };
+  }
+
+  const wardAssets = collect(/hamsa|evil[- ]?eye|protection[-_ ]?hand|rebecca[-_ ]?respawn[-_ ]?sigil/i, 'protection-handsigil visionary-grid');
+  if (wardAssets.length) {
+    manifest.protection = Object.assign({}, manifest.protection || {}, {
+      sigil: {
+        layer: 'protectionSigil',
+        geometry: 'protection_hand',
+        assets: wardAssets,
+        css: 'protection-handsigil'
+      },
+      rite: styleTokens.rituals?.witch_as_coven_protection || null
+    });
+  }
 
   const bridgeRoot = path.resolve(root, '../../bridge');
-  fs.mkdirSync(bridgeRoot, {recursive:true});
+  fs.mkdirSync(bridgeRoot, { recursive: true });
   fs.writeFileSync(path.join(bridgeRoot, 'c99-bridge.json'), JSON.stringify(manifest, null, 2));
-  console.log("Bridge manifest written: /bridge/c99-bridge.json");
+  console.log('Bridge manifest written: /bridge/c99-bridge.json');
 
-  try {
-    const c99A = path.resolve(root, '../../cosmogenesis_learning_engine/public/c99');
-    const c99B = path.resolve(root, '../../cosmogenesis-learning-engine/public/c99'); // alt hyphen
-    for (const c99 of [c99A, c99B]) {
-      if (fs.existsSync(c99)) {
-        fs.mkdirSync(path.join(c99, 'tokens'), {recursive:true});
-        fs.mkdirSync(path.join(c99, 'css'), {recursive:true});
-        fs.copyFileSync(path.resolve(root,'assets','tokens','perm-style.json'), path.join(c99,'tokens','perm-style.json'));
-        fs.copyFileSync(path.resolve(root,'assets','css','perm-style.css'), path.join(c99,'css','perm-style.css'));
-        console.log("Mirrored tokens+css to C99/public:", c99);
-      }
-    }
-  } catch(e) { console.warn("Mirror step skipped:", e.message); }
+  const mirrorTargets = [
+    path.resolve(root, '../../cosmogenesis_learning_engine/public/c99'),
+    path.resolve(root, '../../cosmogenesis-learning-engine/public/c99')
+  ];
 
-  console.log("Art ingest complete. ND-safe ✓");
+  for (const target of mirrorTargets) {
+    if (!fs.existsSync(target)) continue;
+    fs.mkdirSync(path.join(target, 'tokens'), { recursive: true });
+    fs.mkdirSync(path.join(target, 'css'), { recursive: true });
+    fs.copyFileSync(path.resolve(root, 'assets', 'tokens', 'perm-style.json'), path.join(target, 'tokens', 'perm-style.json'));
+    fs.copyFileSync(path.resolve(root, 'assets', 'css', 'perm-style.css'), path.join(target, 'css', 'perm-style.css'));
+    console.log('Mirrored tokens+css to C99/public:', target);
+  }
+
+  console.log('Art ingest complete. ND-safe ✓');
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/cosmogenesis-learning-engine/assets/data/codex.144_99.json
+++ b/cosmogenesis-learning-engine/assets/data/codex.144_99.json
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "name": "Codex 144:99",
+    "version": "1.0.0",
+    "nd_safe": true
+  },
+  "principles": [
+    "144 nodes → 99 gates",
+    "Witch-as-a-Coven: the one contains the many",
+    "Ray VI devotion & transmutation without compulsion",
+    "Hermetic, Tree, Theosophy are selectable flavors",
+    "John Dee lens: empire of mind, service to spirit"
+  ],
+  "counts": {
+    "nodes": 144,
+    "gates": 99
+  },
+  "flavors": {
+    "hermetic": true,
+    "etz_chayyim": true,
+    "theosophy": true,
+    "violet_respawn_alias": true
+  }
+}

--- a/cosmogenesis-learning-engine/assets/data/covens/default.coven.json
+++ b/cosmogenesis-learning-engine/assets/data/covens/default.coven.json
@@ -1,0 +1,12 @@
+{
+  "id": "coven-default",
+  "name": "Cathedral Seed",
+  "witch": "profiles/default.witch.json",
+  "members": ["profiles/default.witch.json"],
+  "packs": ["packs/sample-world.pack.json"],
+  "policy": {
+    "nd_safe": true,
+    "sharing": "private-by-default",
+    "license": "BY creator, non-commercial unless specified"
+  }
+}

--- a/cosmogenesis-learning-engine/assets/data/packs/sample-world.pack.json
+++ b/cosmogenesis-learning-engine/assets/data/packs/sample-world.pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "world-sample-velvet-avalon",
+  "title": "Velvet Avalon Sample",
+  "version": "1.0.0",
+  "witch": "profiles/default.witch.json",
+  "stylepack_key": "velvet-avalon",
+  "tokens": "/public/c99/tokens/perm-style.json",
+  "css": "/public/c99/css/perm-style.css",
+  "flavors": {
+    "hermetic_alchemy": true,
+    "tree_of_life": true,
+    "theosophical_aeons": true
+  },
+  "respawn_alias_violet": true,
+  "between_realm": {
+    "enable": true,
+    "class": "between-narthex",
+    "layer": "inBetweenVeil"
+  },
+  "protection": {
+    "enable": true,
+    "class": "protection-handsigil",
+    "layer": "protectionSigil"
+  },
+  "solfeggio": [396, 417, 528, 639, 741, 852, 963],
+  "egregores_hint": "assets/data/egregores.core.json",
+  "angels_hint": "assets/data/angels72.json",
+  "bridge_overrides": {
+    "adventure.default": "hermetic_alchemy"
+  },
+  "notes": "Portable pack; couture tokens/CSS mirrored."
+}

--- a/cosmogenesis-learning-engine/assets/data/profiles/default.witch.json
+++ b/cosmogenesis-learning-engine/assets/data/profiles/default.witch.json
@@ -1,0 +1,19 @@
+{
+  "id": "witch-default",
+  "name": "Architect-Scribe",
+  "title": "Witch-as-a-Coven",
+  "roles": ["creator", "scribe", "guardian"],
+  "numerology": {
+    "root": 2,
+    "scribe": 11,
+    "star": 22,
+    "guardian": 33
+  },
+  "palette_preference": "deep-velvet",
+  "safety": {
+    "autoplay": false,
+    "strobe": false,
+    "motion": "reduce"
+  },
+  "codex": "assets/data/codex.144_99.json"
+}

--- a/cosmogenesis-learning-engine/tools/build-bridge.js
+++ b/cosmogenesis-learning-engine/tools/build-bridge.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const dataPath = (relative) => path.join(root, 'assets', 'data', relative);
+const outDir = path.join(root, 'public', 'c99');
+fs.mkdirSync(outDir, { recursive: true });
+
+const readJSON = (relative) => {
+  try {
+    return JSON.parse(fs.readFileSync(dataPath(relative), 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+const codex = readJSON('codex.144_99.json') || {};
+const witch = readJSON('profiles/default.witch.json') || {};
+const coven = readJSON('covens/default.coven.json') || {};
+const pack = readJSON('packs/sample-world.pack.json') || {};
+
+const tokensPath = path.join(outDir, 'tokens', 'perm-style.json');
+const cssPath = path.join(outDir, 'css', 'perm-style.css');
+
+const manifest = {
+  meta: { project: 'Cosmogenesis Learning Engine', updated: new Date().toISOString(), nd_safe: true },
+  routes: { tokens: '/c99/tokens/perm-style.json', css: '/c99/css/perm-style.css' },
+  codex,
+  witch,
+  coven,
+  pack,
+  style: {
+    tokens: fs.existsSync(tokensPath) ? '/c99/tokens/perm-style.json' : '',
+    css: fs.existsSync(cssPath) ? '/c99/css/perm-style.css' : ''
+  }
+};
+
+fs.writeFileSync(path.join(outDir, 'bridge.json'), JSON.stringify(manifest, null, 2));
+console.log('Cosmogenesis bridge.json written');

--- a/index.html
+++ b/index.html
@@ -6,10 +6,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-
-    /* ND-safe: calm contrast, no motion, generous breathing room */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     header strong { letter-spacing:0.08em; text-transform:uppercase; font-size:12px; }
     .status { color:var(--muted); font-size:12px; margin-top:2px; }
@@ -17,60 +15,6 @@
     #stage { display:block; width:100%; max-width:1440px; height:auto; box-shadow:0 0 0 1px #1d1d2a; background:#080810; }
     .note { max-width:900px; color:var(--muted); font-size:13px; text-align:center; }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
-
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root {
-      --bg:#0b0b12;
-      --ink:#e8e8f0;
-      --muted:#a6a6c1;
-    }
-
-    html,
-    body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
-    }
-
-    header {
-      padding:12px 16px;
-      border-bottom:1px solid #1d1d2a;
-    }
-
-    header strong {
-      font-size:13px;
-      letter-spacing:0.08em;
-      text-transform:uppercase;
-    }
-
-    .status {
-      margin-top:4px;
-      color:var(--muted);
-      font-size:12px;
-    }
-
-    #stage {
-      display:block;
-      margin:16px auto;
-      box-shadow:0 0 0 1px #1d1d2a;
-      background:#090912;
-    }
-
-    .note {
-      max-width:900px;
-      margin:0 auto 16px;
-      padding:0 16px 24px;
-      color:var(--muted);
-    }
-
-    code {
-      background:#11111a;
-      padding:2px 4px;
-      border-radius:3px;
-    }
-
   </style>
 </head>
 <body>
@@ -84,11 +28,6 @@
     <p class="note">This static renderer paints four calm layers in order: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open this file directly—no external network calls occur.</p>
   </main>
 
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-
-
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
@@ -98,22 +37,13 @@
 
     async function loadJSON(path) {
       try {
-        const res = await fetch(path, { cache:"no-store" });
+        const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
       } catch (error) {
         return null;
       }
     }
-
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        muted:"#a6a6c1",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
 
     function applyShellColours(palette) {
       document.documentElement.style.setProperty("--bg", palette.bg || defaults.palette.bg);
@@ -125,30 +55,38 @@
       return Boolean(value) && typeof value.bg === "string" && typeof value.ink === "string";
     }
 
+    const defaults = {
+      palette: {
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        muted: "#a6a6c1",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      }
+    };
+
     const palette = await loadJSON("./data/palette.json");
     const active = isPalette(palette) ? palette : defaults.palette;
     elStatus.textContent = isPalette(palette) ? "Palette loaded." : "Palette missing; using safe fallback.";
     applyShellColours(active);
 
     const NUM = {
-      THREE:3,
-      SEVEN:7,
-      NINE:9,
-      ELEVEN:11,
-      TWENTYTWO:22,
-      THIRTYTHREE:33,
-      NINETYNINE:99,
-      ONEFORTYFOUR:144
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
     };
 
-    // ND-safe rationale: single render pass, soft palette, layered order without motion.
     renderHelix(ctx, {
-      width:canvas.width,
-      height:canvas.height,
-      palette:{
-        bg:active.bg,
-        ink:active.ink,
-        layers:Array.isArray(active.layers) && active.layers.length > 0 ? active.layers.slice() : defaults.palette.layers
+      width: canvas.width,
+      height: canvas.height,
+      palette: {
+        bg: active.bg,
+        ink: active.ink,
+        layers: Array.isArray(active.layers) && active.layers.length ? active.layers.slice() : defaults.palette.layers
       },
       NUM
     });

--- a/scripts/merge-perm-style.mjs
+++ b/scripts/merge-perm-style.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const basePath = path.resolve('assets/tokens/perm-style.json');
+const addPath = path.resolve('assets/tokens/perm-style.merge.json');
+
+const readJSON = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const writeJSON = (p, o) => fs.writeFileSync(p, JSON.stringify(o, null, 2) + '\n');
+
+function mergeKeepExisting(base, add) {
+  if (Array.isArray(base) && Array.isArray(add)) {
+    return base.length ? base : add;
+  }
+  if (typeof base === 'object' && base && typeof add === 'object' && add) {
+    const out = { ...add, ...base };
+    for (const key of Object.keys(add)) {
+      if (Object.prototype.hasOwnProperty.call(base, key)) {
+        out[key] = mergeKeepExisting(base[key], add[key]);
+      }
+    }
+    return out;
+  }
+  return base ?? add;
+}
+
+const base = fs.existsSync(basePath) ? readJSON(basePath) : {};
+const add = fs.existsSync(addPath) ? readJSON(addPath) : {};
+
+if (!Object.keys(add).length) {
+  console.error('No merge JSON found. Aborting.');
+  process.exit(1);
+}
+
+const merged = mergeKeepExisting(base, add);
+
+merged.meta ??= {};
+merged.meta.nd_safe = true;
+merged.a11y ??= { min_contrast: 4.5, motion: 'reduce', autoplay: false, strobe: false };
+
+const parts = String(merged?.meta?.version || '0.0.0').split('.');
+if (parts.length === 3) {
+  const patch = parseInt(parts[2], 10);
+  parts[2] = Number.isNaN(patch) ? '1' : String(patch + 1);
+  merged.meta.version = parts.join('.');
+}
+
+writeJSON(basePath, merged);
+console.log('✅ perm-style.json merged (existing values preserved). New version:', merged.meta.version);


### PR DESCRIPTION
## Summary
- rebuild `assets/tokens/perm-style.json` and ship the companion `.merge` sidecar so the palette can absorb Circuitum99 updates safely
- append the Circuitum99 effects kit, expose a reusable token→CSS mapper, and load it via the new ES-module bridge
- extend the ingest pipeline, add cosmogenesis Codex/profile/coven/pack JSON, and refresh the static helix renderer docs and shell

## Testing
- `node scripts/merge-perm-style.mjs`
- `node ci/check-tokens-a11y.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d15fede3d483289cc3ab3f9ae34851