### PR TITLE
feat(tokens): enrich perm-style tokens and ND-safe CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ND-safe linter
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  nd-safe:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run ND-safe checks
+        run: node --test tests/nd-safe.test.js

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy static Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload static artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/assets/css/perm-style.css
+++ b/assets/css/perm-style.css
@@ -1,166 +1,338 @@
-:root{
-  /* core surfaces */
-  --void:#0B0B0B; --ink:#141414; --bone:#F8F5EF;
+:root {
+  /* Core surfaces */
+  --void:#0b0b0b;
+  --ink:#141414;
+  --bone:#f8f5ef;
 
-  /* visionary (from data/visionary.json) */
-  --indigo:#280050; --violet:#460082; --blue:#0080FF;
-  --green:#00FF80; --amber:#FFC800; --light:#FFFFFF;
+  /* Visionary spectrum */
+  --indigo:#280050;
+  --violet:#460082;
+  --blue:#0080ff;
+  --green:#00ff80;
+  --amber:#ffc800;
+  --light:#ffffff;
 
-  /* secondary + docs/style/palette.json */
-  --crimson:#B7410E; --gold:#C9A227; --obsidian:#0B0B0B;
-  --rose-quartz:#FFB6C1; --teal-glow:#00CED1; --violet-alt:#8A2BE2;
-  --grail-gold:#D4AF37; --violet-core:#460082; --violet-aura:#BB86FC;
-  --nacre-pearl:#F2F3F4; --avalon-mist:#BCC2C6; --avalon-night:#1C2230;
+  /* Secondary palette */
+  --crimson:#b7410e;
+  --gold:#c9a227;
+  --obsidian:#0b0b0b;
+  --rose-quartz:#ffb6c1;
+  --teal-glow:#00ced1;
+  --violet-alt:#8a2be2;
+  --grail-gold:#d4af37;
+  --violet-core:#460082;
+  --violet-aura:#bb86fc;
+  --nacre-pearl:#f0ead6;
+  --avalon-mist:#bcc2c6;
+  --avalon-night:#1c2230;
+  --fae-mist:#c8d8ff;
+  --fae-glow:#a7f3ce;
+  --star-cobalt:#27408b;
+  --rose-heart:#f6b3c6;
+  --rose-leaf:#6faf7f;
+  --avalon-moss:#4f6b3c;
+  --pink-grace:#f8cdeb;
+  --violet-flame-core:#6b2fe0;
+  --violet-flame-halo:#f0d0ff;
+  --sec-bg:#101018;
+  --sec-ink:#f5f5fa;
+  --sec-edge:#2f2f44;
+  --sec-sun:#f6c177;
+  --sec-sea:#4fb7dd;
+  --sec-fern:#70d39b;
+  --sec-rose:#f5a3b7;
+  --sec-amethyst:#b68cff;
 
-  /* Andrew Gonzalez obsidian scale */
-  --gonz-0:#0b0b0b; --gonz-1:#16121b; --gonz-2:#2a2140; --gonz-3:#5e4ba8; --gonz-4:#e6e6e6;
+  /* Gonzalez obsidian scale */
+  --gonz-0:#0b0b0b;
+  --gonz-1:#16121b;
+  --gonz-2:#2a2140;
+  --gonz-3:#5e4ba8;
+  --gonz-4:#e6e6e6;
 
-  /* line weights */
-  --line-hair:1px; --line-primary:2px; --line-pillar:3px;
+  /* Line weights */
+  --line-hair:1px;
+  --line-primary:2px;
+  --line-pillar:3px;
 
-  /* typography */
+  /* Typography */
   --font-display:"EB Garamond","Junicode",serif;
   --font-gothic:"Cinzel",serif;
   --font-ui:"Inter",system-ui,sans-serif;
-  --scale-h1:1.888rem; --scale-h2:1.555rem; --scale-h3:1.333rem;
-  --scale-body:1rem; --scale-small:.888rem;
+  --scale-h1:1.888rem;
+  --scale-h2:1.555rem;
+  --scale-h3:1.333rem;
+  --scale-body:1rem;
+  --scale-small:.888rem;
 
-  /* a11y */
+  /* ND-safe baseline */
   --min-contrast:4.5;
 }
 
-/* base */
-html{color-scheme:light dark}
-body{
-  margin:0; padding:0;
-  color:var(--bone);
+html { color-scheme: light dark; }
+
+body {
+  margin: 0;
+  padding: 0;
+  color: var(--bone);
+  background: radial-gradient(1200px 700px at 50% 10%, var(--gonz-2) 0%, var(--gonz-1) 45%, var(--void) 100%);
+  font-family: var(--font-ui);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+  letter-spacing: .01em;
+  text-rendering: optimizeLegibility;
+}
+
+h1 { font-size: var(--scale-h1); }
+h2 { font-size: var(--scale-h2); }
+h3 { font-size: var(--scale-h3); }
+
+.sigil {
+  stroke: var(--violet);
+  stroke-width: var(--line-primary);
+  fill: none;
+}
+
+.sigil--hair { stroke-width: var(--line-hair); }
+.sigil--pillar { stroke-width: var(--line-pillar); }
+
+.portal {
+  border: var(--line-primary) solid var(--gold);
+  box-shadow: 0 0 24px 4px rgba(110,0,255,.25);
+  background: linear-gradient(180deg, var(--gonz-2), transparent);
+}
+
+.violet-gate,
+.respawn-gate {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: var(--line-pillar) solid var(--grail-gold);
+  background: radial-gradient(circle at center, var(--violet-core) 0%, transparent 70%);
+  box-shadow: 0 0 24px 4px rgba(138,43,226,.35);
+}
+
+.violet-gate.bg-soft,
+.respawn-gate.bg-soft {
+  background: radial-gradient(circle at center, var(--violet-aura) 0%, transparent 75%);
+}
+
+.visionary-grid {
   background:
-    radial-gradient(1200px 700px at 50% 10%, var(--gonz-2) 0%, var(--gonz-1) 45%, var(--void) 100%);
-  font-family:var(--font-ui);
-  -webkit-font-smoothing:antialiased;
+    repeating-linear-gradient(135deg, rgba(255,255,255,.04) 0 18px, transparent 18px 36px),
+    radial-gradient(circle at 50% 15%, rgba(96,91,168,.35), transparent 70%),
+    linear-gradient(160deg, rgba(24,16,48,.9), rgba(8,8,12,.95));
+  color: var(--bone);
 }
 
-/* headings + ornament glow */
-h1,h2,h3{
-  font-family:var(--font-display);
-  letter-spacing:.01em; text-rendering:optimizeLegibility;
-}
-h1{font-size:var(--scale-h1)}
-h2{font-size:var(--scale-h2)}
-h3{font-size:var(--scale-h3)}
-
-/* sigil lines */
-.sigil{stroke:var(--violet); stroke-width:var(--line-primary); fill:none}
-.sigil--hair{stroke-width:var(--line-hair)}
-.sigil--pillar{stroke-width:var(--line-pillar)}
-
-/* portal frames */
-.portal{
-  border:var(--line-primary) solid var(--gold);
-  box-shadow:0 0 24px 4px rgba(110,0,255,.25);
-  background:linear-gradient(180deg, var(--gonz-2), transparent);
+.raku-patina {
+  background:
+    linear-gradient(120deg, rgba(255,69,0,.25), transparent 60%),
+    linear-gradient(300deg, rgba(110,30,90,.35), rgba(32,12,24,.85));
+  border: 1px solid rgba(255,204,102,.4);
+  color: var(--bone);
 }
 
-/* utility classes */
-.violet-gate,.respawn-gate{
-  width:240px;height:240px;border-radius:50%;
-  border:var(--line-pillar) solid var(--grail-gold);
-  background:radial-gradient(circle at center,var(--violet-core),transparent 70%);
-  box-shadow:0 0 24px 4px rgba(138,43,226,.4);
-}
-.violet-gate.bg-soft,.respawn-gate.bg-soft{
-  background:radial-gradient(circle at center,var(--violet-aura),transparent 70%);
+.gold-leaf {
+  background:
+    linear-gradient(145deg, rgba(255,204,102,.35), rgba(196,168,90,.9)),
+    linear-gradient(45deg, rgba(212,175,55,.35), transparent 60%);
+  color: #1e1405;
 }
 
-.oracle-velvet{
-  background:var(--gonz-2);
-  box-shadow:inset 0 0 24px rgba(0,0,0,.5);
+.nacre-pearl {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255,255,255,.6), transparent 65%),
+    linear-gradient(100deg, rgba(240,234,214,.9), rgba(199,210,224,.75));
+  color: #161621;
 }
 
-.luminous-heart{
-  background:radial-gradient(circle at center,rgba(255,255,255,.8),transparent 70%);
+.moonstone-glow {
+  background:
+    radial-gradient(circle at 50% 0%, rgba(207,216,220,.6), transparent 60%),
+    linear-gradient(200deg, rgba(82,96,138,.55), rgba(16,22,44,.9));
+  color: var(--bone);
 }
 
-.avalon-grove{
-  background:linear-gradient(135deg,var(--avalon-mist),var(--avalon-night));
+.abalone-shell {
+  background:
+    repeating-linear-gradient(90deg, rgba(127,255,212,.35) 0 12px, rgba(255,176,203,.25) 12px 24px, rgba(102,205,170,.3) 24px 36px),
+    linear-gradient(160deg, rgba(16,32,40,.85), rgba(12,18,28,.95));
+  color: var(--bone);
 }
 
-.between-narthex{
-  background:radial-gradient(circle,var(--violet-core),transparent);
-}
-body.allow-motion .between-narthex[data-drift="on"]{
-  animation:narthex-drift 60s linear infinite;
-}
-@keyframes narthex-drift{
-  from{background-position:0 0}
-  to{background-position:100% 100%}
+.oracle-velvet {
+  background: linear-gradient(145deg, var(--gonz-1), var(--gonz-3));
+  color: var(--bone);
+  box-shadow: inset 0 0 24px rgba(0,0,0,.5);
 }
 
-.mode-rail{display:flex;gap:.5rem;flex-wrap:wrap}
-.mode-chip,.solfeggio-chip{
-  padding:.25rem .5rem;border:1px solid var(--gold);border-radius:9999px;font-size:.75rem
+.fae-veil {
+  background:
+    radial-gradient(circle at 30% 20%, rgba(247,240,255,.55), transparent 65%),
+    linear-gradient(160deg, rgba(200,216,255,.35), rgba(167,243,206,.3));
+  border: 1px solid rgba(116,139,212,.35);
+  color: var(--star-cobalt);
 }
 
-.egregore-card,.consecration-angel{
-  border:var(--line-primary) solid var(--gold);
-  border-radius:.5rem;padding:1rem;
-  box-shadow:0 0 12px rgba(0,0,0,.5);
+.rose-gate {
+  background:
+    conic-gradient(from 0deg, rgba(246,179,198,.65), rgba(255,209,230,.35), rgba(111,175,127,.45), rgba(246,179,198,.65));
+  mask: radial-gradient(circle at center, rgba(0,0,0,.85) 55%, transparent 100%);
+  color: var(--rose-heart);
 }
 
-.protection-handsigil{
-  position:relative;width:120px;height:120px;border-radius:50%;
-  background:radial-gradient(circle at center,var(--teal-glow) 0 40%,transparent 40%),
-             radial-gradient(circle at center,transparent 0 55%,var(--nacre-pearl) 55% 70%,transparent 70%);
-  box-shadow:0 0 0 2px var(--grail-gold);
-}
-.protection-handsigil::after{
-  content:"";position:absolute;top:15%;left:15%;width:70%;height:70%;
-  border-radius:50%;border:2px solid var(--grail-gold);
-  box-shadow:0 0 4px var(--gold);
+.violet-flame {
+  position: relative;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(240,208,255,.35) 0%, transparent 65%),
+    radial-gradient(circle at 50% 50%, rgba(107,47,224,.4) 0%, rgba(16,8,32,.95) 85%);
+  border-radius: 50%;
 }
 
-/* ND-safe motion defaults */
-@media (prefers-reduced-motion:reduce){
-  *{animation:none !important; transition:none !important}
-odex/update-world-of-enchantment-assets
-  .between-narthex[data-drift="on"]{animation:none !important}
-
+.violet-flame::after {
+  content: "";
+  position: absolute;
+  inset: 15%;
+  border-radius: 50%;
+  border: 2px solid rgba(240,208,255,.35);
+  box-shadow:
+    0 0 0 4px rgba(107,47,224,.25),
+    0 0 0 12px rgba(240,208,255,.18),
+    0 0 0 20px rgba(107,47,224,.12);
+  pointer-events: none;
 }
 
-/* violet gate + respawn gate */
-.violet-gate,.respawn-gate{
-  width:200px;height:200px;border-radius:50%;
-  border:var(--line-pillar) solid var(--grail_gold,var(--gold));
-  background:radial-gradient(circle at center,var(--violet_core,var(--violet)) 0%,var(--void) 100%);
-}
-.violet-gate.bg-soft,.respawn-gate.bg-soft{
-  background:radial-gradient(circle at center,rgba(110,0,255,.2)0%,transparent 80%);
+.avalon-grove {
+  background: linear-gradient(135deg, var(--avalon-mist), var(--avalon-night));
+  color: var(--bone);
 }
 
-/* oracle velvet */
-.oracle-velvet{background:linear-gradient(145deg,var(--gonz-1),var(--gonz-3));color:var(--bone);}
+.between-narthex {
+  background: rgba(16,16,32,.75);
+  backdrop-filter: blur(2px);
+  border: 1px solid rgba(107,47,224,.35);
+}
 
-/* luminous heart backdrop */
-.luminous-heart{background:radial-gradient(circle at 50% 30%,rgba(255,255,255,.3),transparent 70%),var(--violet_aura,var(--violet));}
+.true-fairy {
+  background:
+    linear-gradient(180deg, rgba(187,134,252,.25), transparent 70%),
+    linear-gradient(45deg, rgba(200,216,255,.2), rgba(255,255,255,.05));
+  color: var(--bone);
+}
 
-/* avalon grove */
-.avalon-grove{background:linear-gradient(180deg,var(--avalon_mist),var(--avalon_night));color:var(--bone);}
+.protection-handsigil {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 45% 45% 40% 40%;
+  background:
+    radial-gradient(circle at 50% 60%, var(--teal-glow) 0 40%, transparent 40%),
+    radial-gradient(circle at center, transparent 0 55%, var(--nacre-pearl) 55% 75%, transparent 75%);
+  box-shadow: 0 0 0 2px var(--grail-gold);
+}
 
-/* between realm narthex */
-.between-narthex{background:rgba(0,0,0,.6);backdrop-filter:blur(2px);}
-body.allow-motion .between-narthex[data-drift="on"]{animation:veil-drift 40s linear infinite;}
-@keyframes veil-drift{from{background-position:0 0;}to{background-position:1000px 0;}}
+.protection-handsigil::before {
+  content: "";
+  position: absolute;
+  top: 12%;
+  left: 20%;
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  border: 2px solid rgba(244,220,170,.55);
+  box-shadow: 0 0 6px rgba(212,175,55,.4);
+}
 
-/* flavor chips */
-.mode-rail{display:flex;gap:.5rem;flex-wrap:wrap;}
-.mode-chip,.solfeggio-chip{padding:.25rem .5rem;border-radius:.25rem;background:var(--ink);border:1px solid var(--gold);font-size:.75rem;}
+.protection-handsigil::after {
+  content: "";
+  position: absolute;
+  top: 6%;
+  left: 32%;
+  width: 36%;
+  height: 18%;
+  border-top-left-radius: 50% 100%;
+  border-top-right-radius: 50% 100%;
+  background: linear-gradient(180deg, rgba(244,198,96,.8), rgba(198,146,54,.6));
+}
 
-/* oracle + angel cards */
-.egregore-card,.consecration-angel{border:var(--line-primary) solid var(--gold_leaf,var(--gold));padding:1rem;background:var(--ink);}
+.morgan-sigil {
+  border: 2px solid rgba(182,140,255,.6);
+  border-radius: 18px;
+  box-shadow: 0 0 0 2px rgba(246,163,183,.35), inset 0 0 24px rgba(70,0,82,.45);
+  background: linear-gradient(160deg, rgba(70,0,82,.6), rgba(31,0,44,.85));
+  color: var(--pink-grace);
+}
 
-/* protection handsigil */
-.protection-handsigil{--size:80px;width:var(--size);height:var(--size);border-radius:40% 40% 35% 35%;background:var(--nacre_pearl,#f0ead6);position:relative;}
-.protection-handsigil::before{content:"";position:absolute;top:15%;left:20%;width:60%;height:60%;border-radius:50%;background:var(--teal_glow);box-shadow:0 0 0 4px var(--gold);}
-.protection-handsigil::after{content:"";position:absolute;top:8%;left:30%;width:40%;height:20%;border-top-left-radius:50% 100%;border-top-right-radius:50% 100%;background:var(--gold);}
-  .between-narthex[data-drift="on"]{animation:none !important}
+.helix-lattice {
+  background:
+    linear-gradient(120deg, rgba(107,47,224,.15) 10%, transparent 10% 20%, rgba(107,47,224,.15) 20% 30%, transparent 30%),
+    linear-gradient(60deg, rgba(111,175,127,.15) 15%, transparent 15% 30%, rgba(111,175,127,.15) 30% 45%, transparent 45%),
+    linear-gradient(180deg, rgba(16,16,32,.92), rgba(8,8,16,.98));
+  background-size: 180px 180px, 180px 180px, auto;
+  border: 1px solid rgba(138,43,226,.25);
+  color: var(--bone);
+}
+
+.mode-rail {
+  display: flex;
+  gap: .5rem;
+  flex-wrap: wrap;
+}
+
+.mode-chip,
+.solfeggio-chip {
+  padding: .25rem .5rem;
+  border: 1px solid var(--gold);
+  border-radius: 9999px;
+  font-size: .75rem;
+  background: rgba(12,12,24,.75);
+  color: var(--bone);
+}
+
+.egregore-card,
+.consecration-angel {
+  border: var(--line-primary) solid var(--gold);
+  border-radius: .5rem;
+  padding: 1rem;
+  box-shadow: 0 0 12px rgba(0,0,0,.45);
+  background: rgba(20,20,28,.85);
+}
+
+.luminous-heart {
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255,255,255,.35), transparent 70%),
+    radial-gradient(circle at center, rgba(187,134,252,.25), transparent 80%);
+}
+
+.fae-banner {
+  padding: 1rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(200,216,255,.3), rgba(167,243,206,.2));
+  color: var(--star-cobalt);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
+body.allow-motion .between-narthex[data-drift="on"] {
+  animation: veil-drift 60s linear infinite;
+}
+
+body.allow-motion .violet-flame[data-wave="on"]::after {
+  animation: flame-pulse 48s ease-in-out infinite;
+}
+
+@keyframes veil-drift {
+  from { background-position: 0 0; }
+  to { background-position: 1000px 0; }
+}
+
+@keyframes flame-pulse {
+  0%, 100% { box-shadow: 0 0 0 4px rgba(107,47,224,.25), 0 0 0 12px rgba(240,208,255,.18), 0 0 0 20px rgba(107,47,224,.12); }
+  50% { box-shadow: 0 0 0 6px rgba(107,47,224,.18), 0 0 0 16px rgba(240,208,255,.12), 0 0 0 26px rgba(107,47,224,.08); }
 }

--- a/assets/tokens/perm-style.json
+++ b/assets/tokens/perm-style.json
@@ -1,8 +1,5 @@
 {
   "meta": {
-codex/update-world-of-enchantment-assets
-    "name": "Circuitum99 -- Perm Style",
-=======
     "name": "circuitum99 -- Perm Style",
     "version": "3.7.0",
     "source": [
@@ -11,82 +8,128 @@ codex/update-world-of-enchantment-assets
       "cosmogenesis/registry/datasets/palettes.core.json"
     ],
     "nd_safe": true,
-odex/update-world-of-enchantment-assets
-=======
-    "notes": "World-of-Enchantment baseline; Avalon fixed; Aeons flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven ward; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer."
- main
     "notes": "World-of-Enchantment baseline; Avalon (Dion Fortune) fixed; Theosophical Aeons available as flavor; Violet Flame ↔ Respawn Gate alias; Witch-as-the-Coven protection sigil encoded; Solfeggio × BioGeometry; Egregores, Consecration Angels, Pillars; True-fairy shimmer."
   },
   "palette": {
     "void": "#0B0B0B",
     "ink": "#141414",
     "bone": "#F8F5EF",
-
     "indigo": "#280050",
     "violet": "#460082",
     "blue": "#0080FF",
     "green": "#00FF80",
     "amber": "#FFC800",
     "light": "#FFFFFF",
-
     "crimson": "#B7410E",
     "gold": "#C9A227",
     "obsidian": "#0B0B0B",
     "rose_quartz": "#FFB6C1",
     "teal_glow": "#00CED1",
     "violet_alt": "#8A2BE2",
-
     "gonzalez_palette": ["#0b0b0b", "#16121b", "#2a2140", "#5e4ba8", "#e6e6e6"],
-    "obsidian_glass": "#1c1c1c",
-    "obsidian_sheen": "#2e2e2e",
+    "obsidian_glass": "#1C1C1C",
+    "obsidian_sheen": "#2E2E2E",
     "obsidian_rainbow": "#545455",
     "shungite": "#252525",
-    "tourmaline": "#1b2e34",
-    "basalt": "#2d2d30",
-    "glint_silver": "#d9dfe4",
-    "lava_ember": "#ff4500",
-    "lava_core": "#b22222",
-    "raku_copper": "#b87333",
+    "tourmaline": "#1B2E34",
+    "basalt": "#2D2D30",
+    "glint_silver": "#D9DFE4",
+    "lava_ember": "#FF4500",
+    "lava_core": "#B22222",
+    "raku_copper": "#B87333",
     "raku_charcoal": "#333333",
-    "raku_violet": "#6a0dad",
-    "raku_azure": "#007fff",
-    "gold_leaf": "#d4af37",
-    "gold_leaf_warm": "#ffcc66",
-    "gold_leaf_cold": "#c0c080",
-    "nacre_pearl": "#f0ead6",
-    "moonstone": "#e0e4f3",
-    "moonstone_glow": "#cfd8dc",
-    "abalone_shell": "#7fffd4",
-    "avalon_mist": "#ccd6d9",
-    "avalon_night": "#1a1a2e",
-    "tor_stone": "#8e8e83",
-    "isle_reed": "#6b8e23",
-    "astral_dusk": "#4b0082",
-    "astral_dawn": "#ffefd5",
-    "starlight_silver": "#f8f8ff",
-    "starlight_gold": "#fff8dc",
-    "violet_core": "#8a2be2",
-    "violet_flare": "#bf00ff",
-    "violet_smoke": "#551a8b",
-    "violet_aura": "#c9a0dc",
-    "grail_gold": "#e4c580"
-    "obsidian_glass": {"base":"#0B0B0B","sheen":"#1A1A1A","rainbow":"#3A3A3A"},
-    "shungite": "#101010",
-    "tourmaline": "#2E3A3F",
-    "basalt": "#2B2B2B",
-    "glint_silver": "#C0C0C0",
-    "lava": {"ember":"#FF4500","core":"#B22222"},
-    "raku": {"copper":"#B87333","charcoal":"#333333","violet":"#6A0DAD","azure":"#007FFF"},
-    "gold_leaf": {"base":"#E6C200","warm":"#FFD700","cold":"#C0B283"},
-    "nacre": {"pearl":"#F2F3F4","moonstone":"#E0E5FF","moonstone_glow":"#A7C7E7","abalone_pink":"#FFC0CB","abalone_green":"#66CDAA","abalone_blue":"#7FFFD4"},
-    "avalon": {"mist":"#BCC2C6","night":"#1C2230","tor_stone":"#8B8C7A","isle_reed":"#556B2F"},
-    "astral": {"sky":"#5AA9E6","violet":"#A06CD5"},
-    "starlight": {"silver":"#E5E9F2","gold":"#F6E27F"},
+    "raku_violet": "#6A0DAD",
+    "raku_azure": "#007FFF",
+    "gold_leaf": "#D4AF37",
+    "gold_leaf_warm": "#FFCC66",
+    "gold_leaf_cold": "#C0C080",
+    "nacre_pearl": "#F0EAD6",
+    "moonstone": "#E0E4F3",
+    "moonstone_glow": "#CFD8DC",
+    "abalone_shell": "#7FFFD4",
+    "avalon_mist": "#CCD6D9",
+    "avalon_night": "#1A1A2E",
+    "tor_stone": "#8E8E83",
+    "isle_reed": "#6B8E23",
+    "astral_dusk": "#4B0082",
+    "astral_dawn": "#FFEFD5",
+    "starlight_silver": "#F8F8FF",
+    "starlight_gold": "#FFF8DC",
     "violet_core": "#460082",
-    "violet_flare": "#8A2BE2",
-    "violet_smoke": "#724A9A",
-    "violet_aura": "#BB86FC",
-    "grail_gold": "#D4AF37"
+    "violet_core_alt": "#8A2BE2",
+    "violet_flare": "#BF00FF",
+    "violet_flare_alt": "#8A2BE2",
+    "violet_smoke": "#551A8B",
+    "violet_smoke_soft": "#724A9A",
+    "violet_aura": "#C9A0DC",
+    "violet_aura_bright": "#BB86FC",
+    "grail_gold": "#E4C580",
+    "grail_gold_bright": "#D4AF37",
+    "obsidian_glass_set": {
+      "base": "#0B0B0B",
+      "sheen": "#1A1A1A",
+      "rainbow": "#3A3A3A"
+    },
+    "shungite_deep": "#101010",
+    "tourmaline_ridge": "#2E3A3F",
+    "basalt_ash": "#2B2B2B",
+    "glint_silver_alt": "#C0C0C0",
+    "lava_set": {
+      "ember": "#FF4500",
+      "core": "#B22222"
+    },
+    "raku_set": {
+      "copper": "#B87333",
+      "charcoal": "#333333",
+      "violet": "#6A0DAD",
+      "azure": "#007FFF"
+    },
+    "gold_leaf_set": {
+      "base": "#E6C200",
+      "warm": "#FFD700",
+      "cold": "#C0B283"
+    },
+    "nacre_set": {
+      "pearl": "#F2F3F4",
+      "moonstone": "#E0E5FF",
+      "moonstone_glow": "#A7C7E7",
+      "abalone_pink": "#FFC0CB",
+      "abalone_green": "#66CDAA",
+      "abalone_blue": "#7FFFD4"
+    },
+    "avalon_set": {
+      "mist": "#BCC2C6",
+      "night": "#1C2230",
+      "tor_stone": "#8B8C7A",
+      "isle_reed": "#556B2F"
+    },
+    "astral_set": {
+      "sky": "#5AA9E6",
+      "violet": "#A06CD5"
+    },
+    "starlight_set": {
+      "silver": "#E5E9F2",
+      "gold": "#F6E27F"
+    },
+    "fae_mist": "#C8D8FF",
+    "fae_glow": "#A7F3CE",
+    "star_cobalt": "#27408B",
+    "rose_heart": "#F6B3C6",
+    "rose_leaf": "#6FAF7F",
+    "avalon_moss": "#4F6B3C",
+    "pink_grace": "#F8CDEB",
+    "violet_flame_core": "#6B2FE0",
+    "violet_flame_halo": "#F0D0FF"
+  },
+  "secondary": {
+    "sec_bg": "#101018",
+    "sec_ink": "#F5F5FA",
+    "sec_edge": "#2F2F44",
+    "sec_sun": "#F6C177",
+    "sec_sea": "#4FB7DD",
+    "sec_fern": "#70D39B",
+    "sec_rose": "#F5A3B7",
+    "sec_amethyst": "#B68CFF"
   },
   "line": {
     "hair": 1,
@@ -97,7 +140,13 @@ odex/update-world-of-enchantment-assets
     "display": "'EB Garamond','Junicode',serif",
     "gothic": "'Cinzel',serif",
     "ui": "'Inter',system-ui,sans-serif",
-    "scale": { "h1": 1.888, "h2": 1.555, "h3": 1.333, "body": 1.0, "small": 0.888 }
+    "scale": {
+      "h1": 1.888,
+      "h2": 1.555,
+      "h3": 1.333,
+      "body": 1,
+      "small": 0.888
+    }
   },
   "geometry": {
     "vesica_ratio": 1.732,
@@ -109,36 +158,104 @@ odex/update-world-of-enchantment-assets
   "layers": {
     "visionary": "visionary-grid",
     "rakuPatina": "raku-patina",
-    "goldLeaf": "goldLeaf",
-    "pearl": "nacre",
-    "moonstone": "adularescence",
+    "goldLeaf": "gold-leaf",
+    "pearl": "nacre-pearl",
+    "moonstone": "moonstone-glow",
     "abalone": "abalone-shell",
     "gonzVelvet": "oracle-velvet",
-    "faeShimmer": "true-fairy",
-    "roseGate": "roseGate",
-    "violetFlame": "violetFlame",
-    "violetGate": "violetGate",
-    "respawnGate": "respawnGate",
-    "avalonGrove": "avalonGrove",
-    "inBetweenVeil": "inBetweenVeil",
-    "trueFairy": "trueFairy",
-    "protectionSigil": "protectionSigil"
+    "faeShimmer": "fae-veil",
+    "roseGate": "rose-gate",
+    "violetFlame": "violet-flame",
+    "violetGate": "violet-gate",
+    "respawnGate": "respawn-gate",
+    "avalonGrove": "avalon-grove",
+    "inBetweenVeil": "between-narthex",
+    "trueFairy": "true-fairy",
+    "protectionSigil": "protection-handsigil",
+    "helixLattice": "helix-lattice"
+  },
+  "layer_aliases": {
+    "visionary_grid": "visionary-grid",
+    "raku-patina": "raku-patina",
+    "goldLeaf": "gold-leaf",
+    "gold_leaf": "gold-leaf",
+    "pearl": "nacre-pearl",
+    "moonstone": "moonstone-glow",
+    "abalone": "abalone-shell",
+    "oracle_velvet": "oracle-velvet",
+    "fae_shimmer": "fae-veil",
+    "rose_gate": "rose-gate",
+    "violet_flame": "violet-flame",
+    "violet_gate": "violet-gate",
+    "respawn_gate": "respawn-gate",
+    "avalon_grove": "avalon-grove",
+    "between_realm": "between-narthex",
+    "true_fairy": "true-fairy",
+    "protection_sigil": "protection-handsigil"
   },
   "materials": {
-    "volcanic_obsidian": ["obsidian_glass","obsidian_sheen","obsidian_rainbow"],
-    "shungite": ["shungite","tourmaline","basalt","glint_silver"],
-    "raku_lineage": ["raku_copper","raku_charcoal","raku_violet","raku_azure"],
-    "gold_leaf": ["gold_leaf","gold_leaf_warm","gold_leaf_cold"],
-    "mother_of_pearl": ["nacre_pearl"],
-    "moonstone": ["moonstone","moonstone_glow"],
-    "abalone": ["abalone_shell"]
+    "groups": {
+      "volcanic_obsidian": ["obsidian_glass", "obsidian_sheen", "obsidian_rainbow"],
+      "shungite": ["shungite", "tourmaline", "basalt", "glint_silver"],
+      "raku_lineage": ["raku_copper", "raku_charcoal", "raku_violet", "raku_azure"],
+      "gold_leaf": ["gold_leaf", "gold_leaf_warm", "gold_leaf_cold"],
+      "mother_of_pearl": ["nacre_pearl"],
+      "moonstone": ["moonstone", "moonstone_glow"],
+      "abalone": ["abalone_shell"]
+    },
+    "order": [
+      "volcanic_obsidian",
+      "shungite",
+      "raku_lineage",
+      "gold_leaf",
+      "mother_of_pearl",
+      "moonstone",
+      "abalone"
+    ]
   },
   "effects": {
-    "stars": "twinkle",
-    "ember_eyes": true
+    "stars": {
+      "token": "twinkle",
+      "nd_safe": true,
+      "notes": "Static twilight shimmer; no flicker."
+    },
+    "ember_eyes": {
+      "enabled": true,
+      "nd_safe": true,
+      "notes": "Slow ember warmth for guardian art; no strobe."
+    },
+    "fae_veil": {
+      "class": "fae-veil",
+      "palette": ["fae_mist", "fae_glow", "star_cobalt"],
+      "nd_safe": true,
+      "notes": "Gossamer Avalon overlay with layered depth."
+    },
+    "violet_flame": {
+      "class": "violet-flame",
+      "steps": ["Invoke", "Rotate", "Transmute", "Replace"],
+      "ray": "VI",
+      "nd_safe": true,
+      "notes": "Four-step radial field; motion only on opt-in."
+    },
+    "rose_gate": {
+      "class": "rose-gate",
+      "geometry": "phi-spiral",
+      "nd_safe": true,
+      "notes": "Petal lattice for heart gateways."
+    },
+    "morgan_sigil": {
+      "class": "morgan-sigil",
+      "nd_safe": true,
+      "notes": "Static protective border; no flash."
+    },
+    "helix_lattice": {
+      "class": "helix-lattice",
+      "nd_safe": true,
+      "notes": "Double-helix weave rendered without motion."
+    }
   },
   "healing": {
-    "solfeggio": {
+    "solfeggio_map": {
       "396": "liberation from fear",
       "417": "transmutation",
       "528": "miracles",
@@ -147,140 +264,88 @@ odex/update-world-of-enchantment-assets
       "852": "return to spirit",
       "963": "oneness"
     },
-    "biogeometry_angles": [27,36,45,63,81]
+    "solfeggio": [
+      { "freq": 396, "theme": "liberation" },
+      { "freq": 417, "theme": "transmutation" },
+      { "freq": 528, "theme": "miracles" },
+      { "freq": 639, "theme": "harmony" },
+      { "freq": 741, "theme": "intuition" },
+      { "freq": 852, "theme": "awakening" },
+      { "freq": 963, "theme": "oneness" }
+    ],
+    "biogeometry_angles": [27, 36, 45, 63, 81]
   },
   "avatars": {
-    "incarnate_self": "Incarnate Self",
-    "rebecca_respawn": {"name":"Rebecca Respawn","numerology":11},
-    "drag_persona": {"name":"Drag Persona","numerology":22},
-    "virelai_ezra_lux": {"name":"Virelai Ezra Lux","numerology":33,"note":"Lavender Quan Yin Reiki"}
+    "index": {
+      "incarnate_self": "Incarnate Self",
+      "rebecca_respawn": { "name": "Rebecca Respawn", "numerology": 11 },
+      "drag_persona": { "name": "Drag Persona", "numerology": 22 },
+      "virelai_ezra_lux": { "name": "Virelai Ezra Lux", "numerology": 33, "note": "Lavender Quan Yin Reiki" }
+    },
+    "list": [
+      { "name": "Incarnate Self", "numerology": 1 },
+      { "name": "Rebecca Respawn", "numerology": 11 },
+      { "name": "Drag Persona", "numerology": 22 },
+      { "name": "Virelai Ezra Lux", "numerology": 33, "note": "Lavender Quan Yin Reiki" }
+    ]
   },
   "avalon": {
-    "current":"Priestess",
-    "service":"Grail",
-    "tor_isle_polarity":true,
-    "round_table_oath":true,
-    "veils":["Outer Isle","Inner Sanctuary","Lady's Veil"]
+    "current": "Priestess",
+    "service": "Grail",
+    "tor_isle_polarity": true,
+    "round_table_oath": true,
+    "veils": {
+      "display": ["Outer Isle", "Inner Sanctuary", "Lady's Veil"],
+      "slug": ["outer_isle", "inner_sanctuary", "ladys_veil"]
+    }
   },
   "between_realm": {
-    "name":"In-Between Astral Narthex",
-    "liminal":"veil eddies and star-motes"
+    "name": "In-Between Astral Narthex",
+    "liminal": "veil eddies and star-motes",
+    "traits": ["liminal_hush", "veil_eddies", "star_motes"]
   },
   "adventure_modes": {
-    "hermetic_alchemy":["nigredo","albedo","citrinitas","rubedo"],
-    "tree_of_life":{"sephiroth":10,"paths":22},
-    "theosophical_aeons":["Sat","Svabhavat","Manvantara","Pralaya","Rounds","Root-Races"]
+    "hermetic_alchemy": ["nigredo", "albedo", "citrinitas", "rubedo"],
+    "tree_of_life": { "sephiroth": 10, "paths": 22 },
+    "theosophical_aeons": ["sat", "svabhavat", "manvantara", "pralaya", "rounds", "root_races"],
+    "aliases": {
+      "theosophical_aeons_display": ["Sat", "Svabhavat", "Manvantara", "Pralaya", "Rounds", "Root-Races"]
+    }
   },
   "rituals": {
     "violet_flame": {
-      "steps":["Invoke","Rotate","Transmute","Replace"],
-      "alias":"respawnGate",
-      "ray":"VI"
-    }
+      "steps": ["Invoke", "Rotate", "Transmute", "Replace"],
+      "alias": "respawnGate",
+      "ray": "VI"
+    },
+    "respawn_gate": {
+      "alias": "violet_flame",
+      "ray": 6
+    },
+    "fae_tea": ["prepare", "sip", "journal"],
+    "journeys": ["middle", "lower", "upper"]
   },
-  "angels": { "consecration": 72 },
-  "pillars": { "columns":["Severity","Mildness","Mercy"], "levels":7 },
-  "egregores": { "ray":"VI", "pillar":"middle" },
+  "angels": {
+    "consecration": 72,
+    "dataset": "consecration_angels_72"
+  },
+  "pillars": {
+    "columns": ["Severity", "Mildness", "Mercy"],
+    "levels": 7
+  },
+  "egregores": {
+    "ray": "VI",
+    "pillar": "middle",
+    "schema": "default",
+    "defaults": { "ray": 6, "pillar": "middle" }
+  },
+  "tarot": {
+    "majors": "egregores"
+  },
   "a11y": {
     "min_contrast": 4.5,
     "motion": "reduce",
     "autoplay": false,
     "strobe": false
-  },
-
-  "layers": {
-    "visionary": "visionary-grid",
-    "rakuPatina": "raku-patina",
-    "goldLeaf": "gold-leaf",
-    "pearl": "pearl",
-    "moonstone": "moonstone",
-    "abalone": "abalone",
-    "gonzVelvet": "gonz-velvet",
-    "faeShimmer": "fae-shimmer",
-    "roseGate": "rose-gate",
-    "violetFlame": "violet-flame",
-    "violetGate": "violet-gate",
-    "respawnGate": "respawn-gate",
-    "avalonGrove": "avalon-grove",
-    "inBetweenVeil": "between-narthex",
-    "trueFairy": "true-fairy",
-    "protectionSigil": "protection-handsigil"
-  },
-
-  "materials": [
-    "volcanic_obsidian",
-    "shungite",
-    "raku_lineage",
-    "gold_leaf",
-    "mother_of_pearl",
-    "moonstone",
-    "abalone"
-  ],
-
-  "effects": {
-    "stars": "twinkle",
-    "ember_eyes": true
-  },
-
-  "healing": {
-    "solfeggio": [
-      {"freq":396,"theme":"liberation"},
-      {"freq":417,"theme":"transmutation"},
-      {"freq":528,"theme":"miracles"},
-      {"freq":639,"theme":"harmony"},
-      {"freq":741,"theme":"intuition"},
-      {"freq":852,"theme":"awakening"},
-      {"freq":963,"theme":"oneness"}
-    ],
-    "biogeometry_angles": [27,36,45,63,81]
-  },
-
-  "avatars": [
-    {"name":"Incarnate Self","numerology":1},
-    {"name":"Rebecca Respawn","numerology":11},
-    {"name":"Drag Persona","numerology":22},
-    {"name":"Virelai Ezra Lux","numerology":33,"note":"Lavender Quan Yin Reiki"}
-  ],
-
-  "avalon": {
-    "priestess_current": true,
-    "grail_service": true,
-    "tor_isle_polarity": true,
-    "round_table_oath": true,
-    "veils": ["outer_isle","inner_sanctuary","ladys_veil"]
-  },
-
-  "between_realm": {
-    "name": "In-Between Astral Narthex",
-    "traits": ["liminal_hush","veil_eddies","star_motes"]
-  },
-
-  "adventure_modes": {
-    "hermetic_alchemy": ["nigredo","albedo","citrinitas","rubedo"],
-    "tree_of_life": {"sephiroth":10,"paths":22},
-    "theosophical_aeons": ["sat","svabhavat","manvantara","pralaya","rounds","root_races"]
-  },
-
-  "rituals": {
-    "violet_flame": ["invoke","rotate","transmute","replace"],
-    "respawn_gate": {"alias":"violet_flame","ray":6}
-  },
-
-  "angels": {
-    "dataset": "consecration_angels_72"
-  },
-
-  "pillars": {
-    "columns": ["severity","mildness","mercy"],
-    "levels": 7
-  },
-
-  "egregores": {
-    "schema": "default",
-    "defaults": {"ray":6,"pillar":"middle"}
-  },
-
-  "tarot": {
-    "majors": "egregores"
   }
 }

--- a/core/build/update-art.js
+++ b/core/build/update-art.js
@@ -82,7 +82,7 @@ async function main(){
   }
 
   const creatures = { dragons:[], daimons:[] };
-  const oracleVelvet=[], angelArt=[], pillarArt=[], egregoreArt=[], betweenRealmAssets=[], protectionSigils=[];
+  const oracleVelvet=[], angelArt=[], pillarArt=[], egregoreArt=[], betweenRealmAssets=[], protectionSigils=[], visionaryOverlays=[];
   const assetEntry = a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type });
   for (const a of assets) {
     const n = a.name.toLowerCase();
@@ -100,6 +100,7 @@ async function main(){
       seal_filter:"rakuCopperIridescence",
       src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:''
     });
+    if (/alex[-_ ]?grey|visionary|sacred|grid/.test(n)) visionaryOverlays.push(assetEntry(a));
     if (/oracle|velvet/.test(n)) oracleVelvet.push(assetEntry(a));
     if (/angel/.test(n)) angelArt.push(assetEntry(a));
     if (/pillar/.test(n)) pillarArt.push(assetEntry(a));
@@ -107,20 +108,13 @@ async function main(){
     if (/between|narthex|veil|threshold/.test(n)) betweenRealmAssets.push({ ...assetEntry(a), class:"between-narthex" });
     if (/hamsa|evil.?eye|logo|ward/.test(n)) protectionSigils.push({ ...assetEntry(a), class:"protection-handsigil", layer:"protectionSigil" });
   }
-
-  const visionaryAssets = assets.filter(a => /alex[-_ ]?grey|visionary|sacred|grid/.test(a.name));
-  const oracleVelvet = assets.filter(a => /oracle|velvet/.test(a.name));
-  const angelArt = assets.filter(a => /angel/.test(a.name));
-  const pillarArt = assets.filter(a => /pillar/.test(a.name));
-  const egregoreArt = assets.filter(a => /egregore/.test(a.name));
-  const betweenAssets = assets.filter(a => /(between|narthex|veil|threshold)/.test(a.name));
-  const wardAssets = assets.filter(a => /(hamsa|evil[-_]?eye|logo|ward)/.test(a.name));
-
   const manifest = {
     meta:{ project:"circuitum99 × Stone Grimoire", updated:new Date().toISOString(), nd_safe:true, generator:"update-art.js" },
     tokens:{ css:"/assets/css/perm-style.css", json:"/assets/tokens/perm-style.json",
       palette:styleTokens.palette||{}, secondary:styleTokens.secondary||{}, layers:styleTokens.layers||{},
-      adventure_modes:styleTokens.adventure_modes||{}, avalon:styleTokens.avalon||{}, between_realm:styleTokens.between_realm||{} },
+      layer_aliases:styleTokens.layer_aliases||{}, materials:styleTokens.materials||{}, effects:styleTokens.effects||{},
+      healing:styleTokens.healing||{}, adventure_modes:styleTokens.adventure_modes||{}, avalon:styleTokens.avalon||{},
+      between_realm:styleTokens.between_realm||{}, avatars:styleTokens.avatars||{} },
     routes:{
       stone_grimoire:{ base:"/", chapels:"/chapels/", assets:"/assets/", bridge:"/bridge/c99-bridge.json" },
       cosmogenesis:{ tokens:"/c99/tokens/perm-style.json", css:"/c99/css/perm-style.css", public:"/c99/", bridge:"/bridge/c99-bridge.json" }
@@ -129,27 +123,16 @@ async function main(){
       id:r.id, title:r.title, element:r.element, tone:r.tone, geometry:r.geometry, stylepack:r.stylepack,
       assets:(assetsByRoom[r.id]||[]).map(a => ({ name:a.name, thumb:`/${a.thumb}`, webp:a.webp?`/${a.webp}`:'', src:`/${a.processed}`, type:a.type }))
     })),
-      angels, creatures,
-      visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-      oracle: oracleVelvet.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      angel_assets: angelArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      pillars: pillarArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      egregores: egregoreArt.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })),
-      between_realm:{ ...(styleTokens.between_realm||{}), assets: betweenAssets.map(a => ({ name:a.name, class:'between-narthex', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
-      protection: wardAssets.length?{ sigil: wardAssets.map(a => ({ name:a.name, class:'protection-handsigil', layer:'protectionSigil', src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) }:undefined,
-      assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type })),
-      rituals:{ violet_flame:{ alias:'respawnGate', ray:'VI', steps:['Invoke','Rotate','Transmute','Replace'] } }
-    };
-    angels:{ list:angels, assets:angelArt },
-    creatures,
-    visionary:{ overlays: visionaryAssets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
+    angels, creatures,
+    visionary:{ overlays: visionaryOverlays },
     oracle: oracleVelvet,
-    pillars:{ assets:pillarArt },
-    egregores:{ assets:egregoreArt },
-    between_realm: Object.assign({}, styleTokens.between_realm||{}, { assets:betweenRealmAssets }),
-    protection:{ sigil: protectionSigils },
-    rituals: styleTokens.rituals || {},
-    assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type }))
+    angel_assets: angelArt,
+    pillars: pillarArt,
+    egregores: egregoreArt,
+    between_realm:{ ...(styleTokens.between_realm||{}), assets: betweenRealmAssets },
+    protection: protectionSigils.length?{ sigil: protectionSigils }:undefined,
+    assets: assets.map(a => ({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type })),
+    rituals: styleTokens.rituals || {}
   };
 
   const bridgeRoot = path.resolve(root, '../../bridge');

--- a/package.json
+++ b/package.json
@@ -7,11 +7,7 @@
     "test": "node tests/interface.test.js",
     "dedupe": "node scripts/deduplicate-repo.mjs",
     "dedupe-file": "node scripts/dedupe.js",
-
     "prebuild": "node scripts/verify-absent.mjs",
-    "build": "vite build"
-
     "build": "node -e \"console.log('offline build: static renderer ready')\""
-
   }
 }

--- a/tests/nd-safe.test.js
+++ b/tests/nd-safe.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const loadTokens = async () => JSON.parse(await readFile("assets/tokens/perm-style.json", "utf8"));
+
+const normalize = (str) => str.replace(/\s+/g, " ");
+
+test("perm-style tokens enforce ND-safe accessibility flags", async () => {
+  const tokens = await loadTokens();
+  const a11y = tokens.a11y ?? {};
+  assert.equal(a11y.strobe, false, "a11y.strobe must remain false");
+  assert.equal(a11y.autoplay, false, "a11y.autoplay must remain false");
+  assert.ok(a11y.motion === "reduce" || a11y.motion === "opt-in", "motion must default to reduce or opt-in");
+  assert.ok(Number(a11y.min_contrast) >= 4.5, "min_contrast must be ≥ 4.5");
+
+  const effects = tokens.effects ?? {};
+  for (const [name, info] of Object.entries(effects)) {
+    if (info && typeof info === "object" && Object.prototype.hasOwnProperty.call(info, "nd_safe")) {
+      assert.equal(info.nd_safe, true, `effect ${name} must declare nd_safe true`);
+    }
+  }
+});
+
+test("perm-style CSS gates any motion behind explicit opt-in", async () => {
+  const css = normalize(await readFile("assets/css/perm-style.css", "utf8"));
+  assert.ok(css.includes("prefers-reduced-motion"), "prefers-reduced-motion safeguard missing");
+  assert.ok(/body\.allow-motion[^}]*between-narthex\[data-drift="on"\]/.test(css), "between-narthex drift must require allow-motion opt-in");
+  assert.ok(/body\.allow-motion[^}]*violet-flame\[data-wave="on"\]/.test(css), "violet flame pulse must require allow-motion opt-in");
+  assert.ok(!/strobe/i.test(css), "CSS must not reference strobe effects");
+});


### PR DESCRIPTION
## Summary
- expand the perm-style token set with extended palettes, layer aliases, ND-safe effects, and ritual metadata
- refresh perm-style.css with static sacred-geometry treatments and explicit reduced-motion gating
- add a focused ND-safe test plus CI and Pages workflows, and clean the package manifest for Node parsing

## Testing
- node --test tests/nd-safe.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1d0837fcc832894d58c1c809ee3c6