### PR TITLE
Potential fix for code scanning alert no. 7: Unvalidated dynamic method call

### DIFF
--- a/chapels/aurora-gate/index.html
+++ b/chapels/aurora-gate/index.html
@@ -92,7 +92,8 @@
     // --- Helpers ---
     const $ = (q)=>document.querySelector(q);
     const params = new URLSearchParams(location.search);
-    let MODE = params.get("mode") || "story";
+    const ALLOWED_MODES = ["story", "game", "art", "research"];
+    let MODE = ALLOWED_MODES.includes(params.get("mode")) ? params.get("mode") : "story";
 
     const views = {
       story(o){ return `<p class="note">${o.role || ""} · narrative lens</p>`; },
@@ -107,7 +108,11 @@
       ops.innerHTML = (bundle.operators||[]).map(o=>`
         <article class="card" role="listitem">
           <h3>${o.label || o.id}</h3>
-          ${views[MODE](o)}
+          ${
+            (Object.prototype.hasOwnProperty.call(views, MODE) && typeof views[MODE] === "function")
+              ? views[MODE](o)
+              : views["story"](o)
+          }
           ${(bundle.symbols||[]).slice(0,4).map(t=>`<span class="tag">#${t}</span>`).join(" ")}
         </article>`).join("");
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/stone-grimoire/security/code-scanning/7](https://github.com/Bekalah/stone-grimoire/security/code-scanning/7)

To fix the problem, we should validate that `MODE` only takes permitted values before performing the dynamic lookup on the `views` object. The best way is to use a whitelist of allowed view modes, e.g. `"story"`, `"game"`, `"art"`, `"research"`, and ensure `views[MODE]` is both an own property and a function. If not, we should fall back to a safe default (such as `"story"`). Specifically:
- Replace the assignment of `MODE` to validate its value before use.
- Update usage of `views[MODE](o)` on line 110 to check that the property exists and is a function before calling.
- Optionally, create a helper function for getting a safe mode.
Changes are needed in the script section of chapels/aurora-gate/index.html, specifically lines involving assignment to `MODE` and usage of `views[MODE]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
