### PR TITLE
Potential fix for code scanning alert no. 2: Server-side URL redirect

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -6,13 +6,28 @@ import url from 'node:url';
 const root = path.resolve('..');
 const port = process.env.PORT || 8080;
 
+function isSafeLocalPath(p) {
+  // Must start with a single "/" and not contain ".." or backslash, and not be an absolute URL
+  return (
+    typeof p === "string" &&
+    p.startsWith("/") &&
+    !p.includes("..") &&
+    !p.includes("\\") &&
+    !/^https?:\/\//i.test(p)
+  );
+}
+
 const server = http.createServer(async (req, res) => {
   const reqUrl = url.parse(req.url).pathname;
   const filePath = path.join(root, reqUrl);
   try {
     const stat = await fs.stat(filePath);
     if (stat.isDirectory()) {
-      res.writeHead(302, {Location: reqUrl.replace(/\/?$/, '/') + 'index.html'});
+      if (isSafeLocalPath(reqUrl)) {
+        res.writeHead(302, {Location: reqUrl.replace(/\/?$/, '/') + 'index.html'});
+      } else {
+        res.writeHead(302, {Location: '/'});
+      }
       res.end();
       return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/stone-grimoire/security/code-scanning/2](https://github.com/Bekalah/stone-grimoire/security/code-scanning/2)

To fix this issue, we need to ensure that the redirect destination is safe and cannot be controlled by a malicious user. The best way is to validate the path before using it in a redirect. Specifically, we should check that the path is local (i.e., does not encode an absolute URL or alter the hostname) and does not allow directory traversal. We can implement an `isSafeLocalPath` helper function to verify that the path:
- Starts with a single slash ("/")
- Does not contain ".." path segments
- Is not an absolute URL (i.e., does not start with "http://" or "https://")

Before performing the redirect in line 15, we should call this function for `reqUrl`, and only proceed if it's safe. Otherwise, redirect to "/" as a fallback. This prevents open redirect vulnerabilities while preserving server functionality.

Changes required:
- Implement `isSafeLocalPath(path)` above the server definition.
- On line 15, check if `reqUrl` is safe before using it in the redirect. If not safe, redirect to "/".
No new dependencies are needed, just a helper function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
