### PR TITLE
Add Cloudflare Pages deployment assets for ND-safe renderer

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,16 @@
+# Keep Cloudflare Pages deploys lean; omit dev-only artifacts.
+.git/
+.github/
+node_modules/
+ci/
+tests/
+scripts/
+fly/
+updates/
+Dockerfile.fly
+fly.toml
+dev-server.js
+*.log
+*.tmp
+*.psd
+*.ai

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -4,14 +4,17 @@ Static, trauma-informed canvas study for the Stone Cathedral helix. Keep the fou
 
 ## Quick Start
 1. Store `index.html`, the `js/` folder, the `data/` folder, and this README in the same directory.
-2. Open `index.html` directly in any modern browser (offline is fine).
-3. Watch the header status — it reports whether the custom palette loaded or the fallback palette took over.
-4. Study or capture the canvas. The geometry is static and safe for ND viewers.
+2. Keep `_headers` and `.cfignore` beside them when you are preparing a Cloudflare Pages deploy — they apply global security headers and trim dev-only files.
+3. Open `index.html` directly in any modern browser (offline is fine).
+4. Watch the header status — it reports whether the custom palette loaded or the fallback palette took over.
+5. Study or capture the canvas. The geometry is static and safe for ND viewers.
 
 ## Files
 - `index.html` — offline shell, palette loader, status + notice discipline, and 1440×900 `<canvas>`.
 - `js/helix-renderer.mjs` — pure ES module that paints the four layers in order.
 - `data/palette.json` — optional palette override; missing or malformed data triggers an inline fallback notice.
+- `_headers` — security + CORS defaults for static hosting.
+- `.cfignore` — excludes dev tooling from the Pages artifact.
 - `README_RENDERER.md` — this guide.
 
 ## Layer Order & Numerology Anchors
@@ -51,3 +54,11 @@ The renderer exposes constants for 3, 7, 9, 11, 22, 33, 99, and 144. Adjust them
 ```
 
 Copy this structure to customise the tones. The script clones arrays internally so palette edits never mutate the defaults.
+
+## Cloudflare Pages (Zero Build Step)
+1. Create a new Pages project that points at this repository.
+2. When prompted for build settings, choose **No build command** and set the output directory to the repo root (`/`).
+3. Publish. `_headers` injects CORS + security headers for every route and keeps `/data/*` cache-free so JSON tweaks land instantly.
+4. `.cfignore` keeps dev-only folders (tests, scripts, CI helpers) out of the artifact so each repo stays self-contained.
+
+If you later assemble multiple projects under a single Worker router, each Pages site will already answer with the correct headers.

--- a/_headers
+++ b/_headers
@@ -1,0 +1,15 @@
+/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, OPTIONS
+  Access-Control-Allow-Headers: Content-Type
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: same-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Cache-Control: public, max-age=3600
+
+/data/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, OPTIONS
+  Access-Control-Allow-Headers: Content-Type
+  Cache-Control: no-store

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -84,6 +84,7 @@ function normalisePalette(palette) {
   return {
     bg: typeof base.bg === "string" ? base.bg : "#0b0b12",
     ink: typeof base.ink === "string" ? base.ink : "#e8e8f0",
+    muted: typeof base.muted === "string" ? base.muted : "#a6a6c1",
     layers: layers.slice()
   };
 }


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages `_headers` file to send ND-safe security headers and keep `/data` responses fresh
- add a `.cfignore` so dev-only folders and tooling stay out of the published artifact
- document the zero-build deployment flow and normalise palette support for the muted token

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d6e46d6c5c8328a9fe83b1365c7ace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added default security and caching headers globally, with no-store caching for data routes.
  * Introduced deployment ignore rules to reduce bundle size and speed up Pages deployments.
  * Expanded theme palette with a “muted” color for improved design flexibility.

* Documentation
  * Updated deployment guide with Cloudflare Pages setup, zero-build workflow, and header behavior.
  * Clarified handling of multiple Pages sites behind a single Worker and listed required static artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->